### PR TITLE
Radix history with single cache

### DIFF
--- a/rspace/src/main/scala/coop/rchain/rspace/history/FastLimitTrieMapCache.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/history/FastLimitTrieMapCache.scala
@@ -23,26 +23,29 @@ class FastLimitTrieMapCache[A, B](maxSize: Int, cache: TrieMap[A, (B, Option[A],
 
     if (optionValue.isEmpty)
       (None, new FastLimitTrieMapCache(maxSize, cache, Some(key), bottomKey))
+    else {
+      val value = Some(optionValue.get._1)
 
-    val value = Some(optionValue.get._1)
-
-    if (topKey.get == key) {
-      (value, new FastLimitTrieMapCache(maxSize, cache, Some(key), bottomKey))
+      if (topKey.get == key) {
+        (value, new FastLimitTrieMapCache(maxSize, cache, Some(key), bottomKey))
+      }
+      else {
+        if (bottomKey.get == key) {
+          val (lastValue, nextKey, _) = cache(bottomKey.get)
+          cache(bottomKey.get) = (lastValue, nextKey, None)
+          val (firstValue, _, prevKey) = cache(bottomKey.get)
+          cache(bottomKey.get) = (firstValue, Some(key), prevKey)
+          (value, new FastLimitTrieMapCache(maxSize, cache, Some(key), cache(key)._2))
+        }
+        else {
+          val (nextValue, nextKey, _) = cache(cache(key)._2.get)
+          cache(cache(key)._2.get) = (nextValue, nextKey, cache(key)._3)
+          val (prevValue, _, prevKey) = cache(cache(key)._2.get)
+          cache(cache(key)._2.get) = (prevValue, cache(key)._2, prevKey)
+          (value, new FastLimitTrieMapCache(maxSize, cache, Some(key), bottomKey))
+        }
+      }
     }
-
-    if (bottomKey.get == key) {
-      val (lastValue, nextKey, _) = cache(bottomKey.get)
-      cache(bottomKey.get) = (lastValue, nextKey, None)
-      val (firstValue, _, prevKey) = cache(bottomKey.get)
-      cache(bottomKey.get) = (firstValue, Some(key), prevKey)
-      (value, new FastLimitTrieMapCache(maxSize, cache, Some(key), cache(key)._2))
-    }
-
-    val (nextValue, nextKey, _) = cache(cache(key)._2.get)
-    cache(cache(key)._2.get) = (nextValue, nextKey, cache(key)._3)
-    val (prevValue, _, prevKey) = cache(cache(key)._2.get)
-    cache(cache(key)._2.get) = (prevValue, cache(key)._2, prevKey)
-    (value, new FastLimitTrieMapCache(maxSize, cache, Some(key), bottomKey))
   }
 
   def update(key: A, value: B): FastLimitTrieMapCache[A, B] = {
@@ -53,15 +56,17 @@ class FastLimitTrieMapCache[A, B](maxSize: Int, cache: TrieMap[A, (B, Option[A],
       cache(key) = (value, nextKey, prevKey)
       get(key)._2
     }
-
-    cache(key) = (value, None, topKey)
-    if (topKey.isEmpty)
-      new FastLimitTrieMapCache(maxSize, cache, Some(key), Some(key))
-
-    val nextBottomKey = clearOldItems()
-    val (value, _, prevKey) = cache(topKey.get)
-    cache(topKey.get) = (value, Some(key), prevKey)
-    new FastLimitTrieMapCache(maxSize, cache, Some(key), nextBottomKey)
+    else {
+      cache(key) = (value, None, topKey)
+      if (topKey.isEmpty)
+        new FastLimitTrieMapCache(maxSize, cache, Some(key), Some(key))
+      else {
+        val nextBottomKey = clearOldItems()
+        val (value, _, prevKey) = cache(topKey.get)
+        cache(topKey.get) = (value, Some(key), prevKey)
+        new FastLimitTrieMapCache(maxSize, cache, Some(key), nextBottomKey)
+      }
+    }
   }
 
   @tailrec

--- a/rspace/src/main/scala/coop/rchain/rspace/history/FastLimitTrieMapCache.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/history/FastLimitTrieMapCache.scala
@@ -16,8 +16,10 @@ object FastLimitTrieMapCache {
   * topKey    - last read item's key
   * bottomKey - most old item's key
   */
-class FastLimitTrieMapCache[A, B](maxSize: Int, cache: TrieMap[A, (B, Option[A], Option[A])] = TrieMap.empty,
-                              topKey: Option[A] = None, bottomKey: Option[A] = None) {
+class FastLimitTrieMapCache[A, B](
+  maxSize: Int,
+  cache: TrieMap[A, (B, Option[A], Option[A])] = TrieMap.empty[A, (B, Option[A], Option[A])],
+  topKey: Option[A] = None, bottomKey: Option[A] = None) {
   def get(key: A): (Option[B], FastLimitTrieMapCache[A, B]) = {
     val optionValue = cache.get(key)
 
@@ -83,7 +85,7 @@ class FastLimitTrieMapCache[A, B](maxSize: Int, cache: TrieMap[A, (B, Option[A],
   private def clearOldItems(): Option[A] = {
     if (maxSize < cache.size) {
       val (oldItems, nextBottomKey) = prepareOldItems(maxSize/3, bottomKey, Nil)
-      oldItems.foreach(_ => cache.remove(_))
+      oldItems.foreach(cache.remove)
       nextBottomKey
     }
     else

--- a/rspace/src/main/scala/coop/rchain/rspace/history/FastLimitTrieMapCache.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/history/FastLimitTrieMapCache.scala
@@ -33,15 +33,15 @@ class FastLimitTrieMapCache[A, B](maxSize: Int, cache: TrieMap[A, (B, Option[A],
         if (bottomKey.get == key) {
           val (lastValue, nextKey, _) = cache(bottomKey.get)
           cache(bottomKey.get) = (lastValue, nextKey, None)
-          val (firstValue, _, prevKey) = cache(bottomKey.get)
-          cache(bottomKey.get) = (firstValue, Some(key), prevKey)
+          val (firstValue, _, prevKey) = cache(topKey.get)
+          cache(topKey.get) = (firstValue, Some(key), prevKey)
           (value, new FastLimitTrieMapCache(maxSize, cache, Some(key), cache(key)._2))
         }
         else {
           val (nextValue, nextKey, _) = cache(cache(key)._2.get)
           cache(cache(key)._2.get) = (nextValue, nextKey, cache(key)._3)
-          val (prevValue, _, prevKey) = cache(cache(key)._2.get)
-          cache(cache(key)._2.get) = (prevValue, cache(key)._2, prevKey)
+          val (prevValue, _, prevKey) = cache(cache(key)._3.get)
+          cache(cache(key)._3.get) = (prevValue, cache(key)._2, prevKey)
           (value, new FastLimitTrieMapCache(maxSize, cache, Some(key), bottomKey))
         }
       }

--- a/rspace/src/main/scala/coop/rchain/rspace/history/FastLimitTrieMapCache.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/history/FastLimitTrieMapCache.scala
@@ -1,0 +1,64 @@
+package coop.rchain.rspace.history
+import scala.collection.concurrent.TrieMap
+
+/*
+  Draft variant of single cache (for reading) for several RadixHistory instances
+  TODO: thread safety, increase speed
+ */
+
+object FastLimitTrieMapCache {
+  def apply[A, B](maxSize: Int): FastLimitTrieMapCache[A, B] = new FastLimitTrieMapCache[A, B](maxSize)
+}
+/*
+  * maxSize   - values count after which old records should be cleared
+  * cache     - TrieMap[key, (value, Option[nextKey], Option[prevKey])]; nextKey closer to topKey; prevKey closer to bottomKey;
+  * topKey    - last read item's key
+  * bottomKey - most old item's key
+  */
+class FastLimitTrieMapCache[A, B](maxSize: Int, cache: TrieMap[A, (B, Option[A], Option[A])] = TrieMap.empty,
+                              topKey: Option[A] = None, bottomKey: Option[A] = None) {
+  def get(key: A): (Option[B], FastLimitTrieMapCache[A, B]) = {
+    val optionValue = cache.get(key)
+
+    if (optionValue.isEmpty)
+      (None, new FastLimitTrieMapCache(maxSize, cache, Some(key), bottomKey))
+
+    val value = Some(optionValue.get._1)
+
+    if (topKey.get == key) {
+      (value, new FastLimitTrieMapCache(maxSize, cache, Some(key), bottomKey))
+    }
+
+    if (bottomKey.get == key) {
+      val (lastValue, nextKey, _) = cache(bottomKey.get)
+      cache(bottomKey.get) = (lastValue, nextKey, None)
+      val (firstValue, _, prevKey) = cache(bottomKey.get)
+      cache(bottomKey.get) = (firstValue, Some(key), prevKey)
+      (value, new FastLimitTrieMapCache(maxSize, cache, Some(key), cache(key)._2))
+    }
+
+    val (nextValue, nextKey, _) = cache(cache(key)._2.get)
+    cache(cache(key)._2.get) = (nextValue, nextKey, cache(key)._3)
+    val (prevValue, _, prevKey) = cache(cache(key)._2.get)
+    cache(cache(key)._2.get) = (prevValue, cache(key)._2, prevKey)
+    (value, new FastLimitTrieMapCache(maxSize, cache, Some(key), bottomKey))
+  }
+
+  def update(key: A, value: B): FastLimitTrieMapCache[A, B] = {
+    val optionValue = cache.get(key)
+
+    if (optionValue.isDefined) {
+      val (_, nextKey, prevKey) = cache(key)
+      cache(key) = (value, nextKey, prevKey)
+      get(key)._2
+    }
+
+    cache(key) = (value, None, topKey)
+    if (topKey.isEmpty)
+      new FastLimitTrieMapCache(maxSize, cache, Some(key), Some(key))
+
+    val (value, _, prevKey) = cache(topKey.get)
+    cache(topKey.get) = (value, Some(key), prevKey)
+    new FastLimitTrieMapCache(maxSize, cache, Some(key), bottomKey)
+  }
+}

--- a/rspace/src/main/scala/coop/rchain/rspace/history/FastLimitTrieMapCache.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/history/FastLimitTrieMapCache.scala
@@ -15,7 +15,7 @@ import scala.collection.concurrent.TrieMap
   * topKey    - last read item's key
   * bottomKey - most old item's key
   */
-class FastLimitTrieMapCacheFunc[A, B](
+class FastLimitTrieMapCache[A, B](
   maxSize: Int,
   cache: TrieMap[A, (B, Option[A], Option[A])] = TrieMap.empty[A, (B, Option[A], Option[A])],
   var topKey: Option[A] = None, var bottomKey: Option[A] = None) {

--- a/rspace/src/main/scala/coop/rchain/rspace/history/FastLimitTrieMapCacheFunc.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/history/FastLimitTrieMapCacheFunc.scala
@@ -1,5 +1,4 @@
 package coop.rchain.rspace.history
-
 import scala.annotation.tailrec
 import scala.collection.concurrent.TrieMap
 
@@ -8,64 +7,66 @@ import scala.collection.concurrent.TrieMap
   TODO: thread safety, increase speed
  */
 
-
+object FastLimitTrieMapCache {
+  def apply[A, B](maxSize: Int): FastLimitTrieMapCache[A, B] = new FastLimitTrieMapCache[A, B](maxSize)
+}
 /*
   * maxSize   - values count after which old records should be cleared
   * cache     - TrieMap[key, (value, Option[nextKey], Option[prevKey])]; nextKey closer to topKey; prevKey closer to bottomKey;
   * topKey    - last read item's key
   * bottomKey - most old item's key
   */
-class FastLimitTrieMapCacheFunc[A, B](
+class FastLimitTrieMapCache[A, B](
   maxSize: Int,
   cache: TrieMap[A, (B, Option[A], Option[A])] = TrieMap.empty[A, (B, Option[A], Option[A])],
-  var topKey: Option[A] = None, var bottomKey: Option[A] = None) {
-  def get(key: A): Option[B] = {
+  topKey: Option[A] = None, bottomKey: Option[A] = None) {
+  def get(key: A): (Option[B], FastLimitTrieMapCache[A, B]) = {
     val optionValue = cache.get(key)
 
     if (optionValue.isEmpty)
-      None
+      (None, new FastLimitTrieMapCache(maxSize, cache, Some(key), bottomKey))
     else {
-      if (topKey.get != key) {
+      val value = Some(optionValue.get._1)
+
+      if (topKey.get == key) {
+        (value, new FastLimitTrieMapCache(maxSize, cache, Some(key), bottomKey))
+      }
+      else {
         if (bottomKey.get == key) {
           val (lastValue, nextKey, _) = cache(bottomKey.get)
           cache(bottomKey.get) = (lastValue, nextKey, None)
           val (firstValue, _, prevKey) = cache(topKey.get)
           cache(topKey.get) = (firstValue, Some(key), prevKey)
-          topKey = Some(key)
-          bottomKey = cache(key)._2
+          (value, new FastLimitTrieMapCache(maxSize, cache, Some(key), cache(key)._2))
         }
         else {
           val (nextValue, nextKey, _) = cache(cache(key)._2.get)
           cache(cache(key)._2.get) = (nextValue, nextKey, cache(key)._3)
           val (prevValue, _, prevKey) = cache(cache(key)._3.get)
           cache(cache(key)._3.get) = (prevValue, cache(key)._2, prevKey)
-          topKey = Some(key)
+          (value, new FastLimitTrieMapCache(maxSize, cache, Some(key), bottomKey))
         }
       }
-      Some(optionValue.get._1)
     }
   }
 
-  def update(key: A, value: B): Unit = {
+  def update(key: A, value: B): FastLimitTrieMapCache[A, B] = {
     val optionValue = cache.get(key)
 
     if (optionValue.isDefined) {
       val (_, nextKey, prevKey) = cache(key)
       cache(key) = (value, nextKey, prevKey)
-      get(key)
+      get(key)._2
     }
     else {
       cache(key) = (value, None, topKey)
-      if (topKey.isEmpty) {
-        topKey = Some(key)
-        bottomKey = Some(key)
-      }
+      if (topKey.isEmpty)
+        new FastLimitTrieMapCache(maxSize, cache, Some(key), Some(key))
       else {
         val nextBottomKey = clearOldItems()
         val (value, _, prevKey) = cache(topKey.get)
         cache(topKey.get) = (value, Some(key), prevKey)
-        topKey = Some(key)
-        bottomKey = nextBottomKey
+        new FastLimitTrieMapCache(maxSize, cache, Some(key), nextBottomKey)
       }
     }
   }

--- a/rspace/src/main/scala/coop/rchain/rspace/history/FastLimitTrieMapCacheFunc.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/history/FastLimitTrieMapCacheFunc.scala
@@ -15,8 +15,10 @@ import scala.collection.concurrent.TrieMap
   * topKey    - last read item's key
   * bottomKey - most old item's key
   */
-class FastLimitTrieMapCacheFunc[A, B](maxSize: Int, cache: TrieMap[A, (B, Option[A], Option[A])] = TrieMap.empty,
-                                      var topKey: Option[A] = None, var bottomKey: Option[A] = None) {
+class FastLimitTrieMapCacheFunc[A, B](
+  maxSize: Int,
+  cache: TrieMap[A, (B, Option[A], Option[A])] = TrieMap.empty[A, (B, Option[A], Option[A])],
+  var topKey: Option[A] = None, var bottomKey: Option[A] = None) {
   def get(key: A): Option[B] = {
     val optionValue = cache.get(key)
 
@@ -82,7 +84,7 @@ class FastLimitTrieMapCacheFunc[A, B](maxSize: Int, cache: TrieMap[A, (B, Option
   private def clearOldItems(): Option[A] = {
     if (maxSize < cache.size) {
       val (oldItems, nextBottomKey) = prepareOldItems(maxSize/3, bottomKey, Nil)
-      oldItems.foreach(_ => cache.remove(_))
+      oldItems.foreach(cache.remove)
       nextBottomKey
     }
     else

--- a/rspace/src/main/scala/coop/rchain/rspace/history/FastLimitTrieMapCacheFunc.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/history/FastLimitTrieMapCacheFunc.scala
@@ -1,0 +1,91 @@
+package coop.rchain.rspace.history
+
+import scala.annotation.tailrec
+import scala.collection.concurrent.TrieMap
+
+/*
+  Draft variant of single cache (for reading) for several RadixHistory instances
+  TODO: thread safety, increase speed
+ */
+
+
+/*
+  * maxSize   - values count after which old records should be cleared
+  * cache     - TrieMap[key, (value, Option[nextKey], Option[prevKey])]; nextKey closer to topKey; prevKey closer to bottomKey;
+  * topKey    - last read item's key
+  * bottomKey - most old item's key
+  */
+class FastLimitTrieMapCacheFunc[A, B](maxSize: Int, cache: TrieMap[A, (B, Option[A], Option[A])] = TrieMap.empty,
+                                      var topKey: Option[A] = None, var bottomKey: Option[A] = None) {
+  def get(key: A): Option[B] = {
+    val optionValue = cache.get(key)
+
+    if (optionValue.isEmpty)
+      None
+    else {
+      if (topKey.get != key) {
+        if (bottomKey.get == key) {
+          val (lastValue, nextKey, _) = cache(bottomKey.get)
+          cache(bottomKey.get) = (lastValue, nextKey, None)
+          val (firstValue, _, prevKey) = cache(topKey.get)
+          cache(topKey.get) = (firstValue, Some(key), prevKey)
+          topKey = Some(key)
+          bottomKey = cache(key)._2
+        }
+        else {
+          val (nextValue, nextKey, _) = cache(cache(key)._2.get)
+          cache(cache(key)._2.get) = (nextValue, nextKey, cache(key)._3)
+          val (prevValue, _, prevKey) = cache(cache(key)._3.get)
+          cache(cache(key)._3.get) = (prevValue, cache(key)._2, prevKey)
+          topKey = Some(key)
+        }
+      }
+      Some(optionValue.get._1)
+    }
+  }
+
+  def update(key: A, value: B): Unit = {
+    val optionValue = cache.get(key)
+
+    if (optionValue.isDefined) {
+      val (_, nextKey, prevKey) = cache(key)
+      cache(key) = (value, nextKey, prevKey)
+      get(key)
+    }
+    else {
+      cache(key) = (value, None, topKey)
+      if (topKey.isEmpty) {
+        topKey = Some(key)
+        bottomKey = Some(key)
+      }
+      else {
+        val nextBottomKey = clearOldItems()
+        val (value, _, prevKey) = cache(topKey.get)
+        cache(topKey.get) = (value, Some(key), prevKey)
+        topKey = Some(key)
+        bottomKey = nextBottomKey
+      }
+    }
+  }
+
+  @tailrec
+  private def prepareOldItems(oldItemsCount: Int, bottomKey: Option[A],
+                              currentOldItemsList: List[A]): (List[A], Option[A]) = {
+    if (bottomKey.isEmpty)
+      (currentOldItemsList, bottomKey)
+    else {
+      val nextBottomKey = cache(bottomKey.get)._2
+      prepareOldItems(oldItemsCount - 1, nextBottomKey, bottomKey.get::currentOldItemsList)
+    }
+  }
+
+  private def clearOldItems(): Option[A] = {
+    if (maxSize < cache.size) {
+      val (oldItems, nextBottomKey) = prepareOldItems(maxSize/3, bottomKey, Nil)
+      oldItems.foreach(_ => cache.remove(_))
+      nextBottomKey
+    }
+    else
+      bottomKey
+  }
+}

--- a/rspace/src/main/scala/coop/rchain/rspace/history/LimitTrieMapCache.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/history/LimitTrieMapCache.scala
@@ -1,0 +1,32 @@
+/*
+  Draft variant of single cache (for reading) for several RadixHistory instances
+  TODO: thread safety, increase speed
+ */
+package coop.rchain.rspace.history
+import scala.collection.concurrent.TrieMap
+import java.util.concurrent.ConcurrentLinkedQueue
+
+object LimitTrieMapCache {
+  def apply[A, B](maxSize: Int): LimitTrieMapCache[A, B] = new LimitTrieMapCache[A, B](maxSize)
+}
+
+class LimitTrieMapCache[A, B](maxSize: Int) {
+  private val cache: TrieMap[A, B]            = TrieMap.empty
+  private val queue: ConcurrentLinkedQueue[A] = new ConcurrentLinkedQueue()
+
+  private def addKeyToQueue(key: A): Unit = {
+    { val _ = queue.remove(key) }
+    { val _ = queue.add(key) }
+    (1 to (queue.size - maxSize)).foreach(_ => cache.remove(queue.remove()))
+  }
+
+  def get(key: A): Option[B] = {
+    addKeyToQueue(key)
+    cache.get(key)
+  }
+
+  def update(key: A, value: B): Unit = {
+    addKeyToQueue(key)
+    cache.update(key, value)
+  }
+}

--- a/rspace/src/main/scala/coop/rchain/rspace/history/RadixTreeWithExternReadCache.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/history/RadixTreeWithExternReadCache.scala
@@ -1,8 +1,8 @@
 package coop.rchain.rspace.history
 
+import cats.Parallel
 import cats.effect.Sync
 import cats.syntax.all._
-import cats.{Monad, Parallel}
 import coop.rchain.shared.syntax._
 import coop.rchain.store.KeyValueTypedStore
 import scodec.bits.ByteVector
@@ -10,34 +10,49 @@ import scodec.bits.ByteVector
 import scala.annotation.tailrec
 import scala.collection.concurrent.TrieMap
 
-/**
-  * Radix Tree implementation
-  */
-object RadixTreeWithExternReadCache {
+object RadixTree {
 
   /**
-    * Node structure (EmptyItem, Leaf and NodePointer)
-    * There is only one type of element in Tree [[Node]] = Vector[Item]
+    * Described items which contain in [[Node]].
     */
   sealed trait Item
-  final case object EmptyItem                                   extends Item
-  final case class Leaf(prefix: ByteVector, value: ByteVector)  extends Item
+
+  /**
+    * Empty item
+    */
+  final case object EmptyItem extends Item
+
+  /**
+    * Item which contain data.
+    */
+  final case class Leaf(prefix: ByteVector, value: ByteVector) extends Item
+
+  /**
+    * Item which contain pointer for child [[Node]]
+    */
   final case class NodePtr(prefix: ByteVector, ptr: ByteVector) extends Item
 
+  /**
+    * Base type for nodes in Radix History.
+    *
+    * Always contains 256 [[Item]]
+    */
   type Node = Vector[Item]
 
   /**
-    * number of items always constant
+    * Number of items always constant.
     */
   val numItems = 256
 
   /**
-    * Empty node consists only of [[EmptyItem]]'s
+    * Empty node consists only of [[EmptyItem]]'s.
     */
   val emptyNode: Node = (0 until numItems).map(_ => EmptyItem).toVector
 
   /**
     * Binary codecs for serializing/deserializing Node in Radix tree
+    *
+    * {{{
     * Coding structure for items:
     *   EmptyItem                   - Empty (not encode)
 
@@ -48,15 +63,25 @@ object RadixTreeWithExternReadCache {
     *   NodePtr(prefix,ptr)   -> [item number] [second byte] [prefix0]..[prefixM] [ptr0]..[ptr31]
     *                               where is: [second byte] -> bit7 = 1 (NodePtr identifier)
     *                                                          bit6..bit0 - prefix length = M (from 0 to 127)
+    *
+    * For example encode this Node which contains 2 non-empty items (number 1 and number 2):
+    * (0)[Empty] (1)[Leaf(prefix:0xFFFF,value:0x00..0001)] (2)[NodePtr(prefix:empty,value:0xFF..FFFF)] (3)...(255)[Empty].
+    * Encoded data = 0x0102FFFF0000000000000000000000000000000000000000000000000000000000000001
+    *                  0280FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF
+    * where: item 1 (number_secondByte_prefix_value) = 01_02_FFFF_00..0001
+    *        item 2 (number_secondByte_prefix_value) = 02_80_empty_FF..FFFF
+    * }}}
     */
-  object codecs {
-    private val defSize  = 32
-    private val headSize = 2 //2 bytes: first - item number, second - second byte
+  object Codecs {
+    private val defSize  = 32 // Default size for non-empty item data
+    private val headSize = 2  // 2 bytes: first - item number, second - second byte
 
+    /** Serialization [[Node]] to [[ByteVector]]
+      */
     def encode(node: Node): ByteVector = {
-      //calculating size of buffer
-      val sizeNode = node.size
 
+      // Calculating size of serialized data
+      val sizeNode = node.size
       @tailrec
       def loopSize(index: Int, size: Int): Int =
         if (sizeNode > index)
@@ -65,105 +90,127 @@ object RadixTreeWithExternReadCache {
 
             case Leaf(leafPrefix, value) =>
               val sizePrefix = leafPrefix.size.toInt
-              assert(sizePrefix <= 127, "error during serialization (size of prefix more than 127)")
+              assert(sizePrefix <= 127, "Error during serialization: size of prefix more than 127.")
               assert(
                 value.size == defSize,
-                "error during serialization (size of leafValue not equal 32)"
+                "Error during serialization: size of leafValue not equal 32."
               )
               loopSize(index + 1, size + headSize + sizePrefix + defSize)
 
             case NodePtr(ptrPrefix, ptr) =>
               val sizePrefix = ptrPrefix.size.toInt
-              assert(sizePrefix <= 127, "error during serialization (size of prefix more than 127)")
+              assert(sizePrefix <= 127, "Error during serialization: size of prefix more than 127.")
               assert(
                 ptr.size == defSize,
-                "error during serialization (size of ptrPrefix not equal 32)"
+                "Error during serialization: size of ptrPrefix not equal 32."
               )
               loopSize(index + 1, size + headSize + sizePrefix + defSize)
           } else size
 
-      val size = loopSize(0, 0)
-      //put in the buffer
+      val size = loopSize(0, 0) // Calculating size
 
-      val arr = new Array[Byte](size)
+      val arr = new Array[Byte](size) //Allocation memory
+
+      // Serialization (fill allocated memory)
       @tailrec
       def loopFill(numItem: Int, idx0: Int): Array[Byte] =
-        if (idx0 == size) arr
+        if (idx0 == size) arr // Happy end (return serializing data).
         else {
           node(numItem) match {
-            case EmptyItem => loopFill(numItem + 1, idx0)
+            // If current item is empty - just skip serialization of this item
+            case EmptyItem => loopFill(numItem + 1, idx0) // Loop to the next item.
 
             case Leaf(prefix, value) =>
+              // Fill first byte - item number
               arr(idx0) = numItem.toByte
-              val idxSecondByte   = idx0 + 1
-              val idxPrefixStart  = idxSecondByte + 1
-              val prefixSize: Int = prefix.size.toInt
-              //size & 01111111b
-              arr(idxSecondByte) = (prefixSize & 0x7F).toByte //second byte - type and size of prefix
-              for (i <- 0 until prefixSize) arr(idxPrefixStart + i) = prefix(i.toLong)
-              val idxValueStart = idxPrefixStart + prefixSize
-              for (i <- 0 until defSize) arr(idxValueStart + i) = value(i.toLong)
-              loopFill(numItem + 1, idxValueStart + defSize)
-            case NodePtr(prefix, ptr) =>
-              arr(idx0) = numItem.toByte
+              // Fill second byte - Leaf identifier (most significant bit = 0) and prefixSize (lower 7 bits = size)
               val idxSecondByte   = idx0 + 1
               val prefixSize: Int = prefix.size.toInt
-              //10000000b | (size & 01111111b)
-              arr(idxSecondByte) = (0x80 | (prefixSize & 0x7F)).toByte //second byte - type and size of prefix
+              arr(idxSecondByte) = (prefixSize & 0x7F).toByte // (size & 01111111b)
+              // Fill prefix
               val idxPrefixStart = idxSecondByte + 1
               for (i <- 0 until prefixSize) arr(idxPrefixStart + i) = prefix(i.toLong)
+              // Fill leafValue
+              val idxValueStart = idxPrefixStart + prefixSize
+              for (i <- 0 until defSize) arr(idxValueStart + i) = value(i.toLong)
+              loopFill(numItem + 1, idxValueStart + defSize) // Loop to the next item.
+
+            case NodePtr(prefix, ptr) =>
+              // Fill first byte - item number
+              arr(idx0) = numItem.toByte
+              // Fill second byte - NodePtr identifier (most significant bit = 1) and prefixSize (lower 7 bits = size)
+              val idxSecondByte   = idx0 + 1
+              val prefixSize: Int = prefix.size.toInt
+              arr(idxSecondByte) = (0x80 | (prefixSize & 0x7F)).toByte // 10000000b | (size & 01111111b)
+              // Fill prefix
+              val idxPrefixStart = idxSecondByte + 1
+              for (i <- 0 until prefixSize) arr(idxPrefixStart + i) = prefix(i.toLong)
+              // Fill ptr
               val idxPtrStart = idxPrefixStart + prefixSize
               for (i <- 0 until defSize) arr(idxPtrStart + i) = ptr(i.toLong)
-              loopFill(numItem + 1, idxPtrStart + defSize)
+              loopFill(numItem + 1, idxPtrStart + defSize) // Loop to the next item.
           }
         }
       ByteVector(loopFill(0, 0))
     }
 
+    /** Deserialization [[ByteVector]] to [[Node]]
+      */
     def decode(bv: ByteVector): Node = {
       val arr     = bv.toArray
       val maxSize = arr.length
       @tailrec
+      // Each loop decodes one non-empty item.
       def loop(idx0: Int, node: Node): Node =
-        if (idx0 == maxSize) node
+        if (idx0 == maxSize) node // End of deserialization
         else {
           val (idx0Next, nodeNext) = try {
-            val numItem: Int = byteToInt(arr(idx0))
+            val numItem: Int = byteToInt(arr(idx0)) // Take first byte - it's item's number
             assert(
               node(numItem) == EmptyItem,
-              "error during deserialization (wrong number of item)"
+              "Error during deserialization: wrong number of item."
             )
             val idx1       = idx0 + 1
-            val secondByte = arr(idx1)
+            val secondByte = arr(idx1) // Take second byte
 
-            val prefixSize: Int = secondByte & 0x7F
+            // Decoding prefix
+            val prefixSize: Int = secondByte & 0x7F // Lower 7 bits - it's size of prefix (0..127).
             val prefix          = new Array[Byte](prefixSize)
             val idxPrefixStart  = idx1 + 1
-            for (i <- 0 until prefixSize) prefix(i) = arr(idxPrefixStart + i)
+            for (i <- 0 until prefixSize) prefix(i) = arr(idxPrefixStart + i) // Take prefix
+
+            // Decoding leaf or nodePtr data
             val valOrPtr         = new Array[Byte](defSize)
             val idxValOrPtrStart = idxPrefixStart + prefixSize
-            for (i <- 0 until defSize) valOrPtr(i) = arr(idxValOrPtrStart + i)
-            val idx0Next = idxValOrPtrStart + defSize
-            val item = if ((secondByte & 0x80) == 0x00) { //Leaf
+            for (i <- 0 until defSize)
+              valOrPtr(i) = arr(idxValOrPtrStart + i) // Take next 32 bytes - it's data
+
+            val idx0Next = idxValOrPtrStart + defSize // Calculating start position for next loop
+
+            // Decoding type of non-empty item
+            val item = if ((secondByte & 0x80) == 0x00) { // If first bit 0 - decoding as Leaf
               Leaf(ByteVector(prefix), ByteVector(valOrPtr))
-            } else { //NodePtr
-              NodePtr(ByteVector(prefix), ByteVector(valOrPtr))
+            } else {
+              NodePtr(ByteVector(prefix), ByteVector(valOrPtr)) // If first bit 1 - decoding as NodePtr.
             }
+
             (idx0Next, node.updated(numItem, item))
           } catch {
             case _: Exception =>
-              assert(assertion = false, "error during deserialization (out of range)")
+              assert(assertion = false, "Error during deserialization: out of range")
               (maxSize, emptyNode)
           }
-          loop(idx0Next, nodeNext)
+          loop(idx0Next, nodeNext) // Try to decode next item.
         }
+
       loop(0, emptyNode)
     }
   }
 
   /**
     * Find the common part of b1 and b2.
-    * Return (Common part , rest of b1, rest of b2).
+    *
+    * @return (Common part , rest of b1, rest of b2).
     */
   def commonPrefix(b1: ByteVector, b2: ByteVector): (ByteVector, ByteVector, ByteVector) = {
     @tailrec
@@ -185,75 +232,91 @@ object RadixTreeWithExternReadCache {
 
   /**
     * Hashing serial data.
-    * Return Blake2b256 hash of input data
+    *
+    * @return Blake2b256 hash of input data.
     */
   def hashNode(node: Node): (ByteVector, ByteVector) = {
     import coop.rchain.crypto.hash.Blake2b256
-    val bytes = codecs.encode(node)
+    val bytes = Codecs.encode(node)
     (ByteVector(Blake2b256.hash(bytes)), bytes)
   }
 
   def byteToInt(b: Byte): Int = b & 0xff
 
   /**
-    * Which element counts the skip&take counter?
-    */
-  sealed trait CountableItem
-  final case object calculateNodes extends CountableItem
-  final case object calculateLeafs extends CountableItem
-
-  /**
-    * Data for return
+    * Data returned after export
+    *
+    * @param nPrefixes Node prefixes
+    * @param nKeys Node KVDB keys
+    * @param nValues Node KVDB values
+    * @param lPrefixes Leaf prefixes
+    * @param lValues Leaf values (it's pointer for data in datastore)
     */
   final case class ExportData(
-      nP: Seq[ByteVector], //nodePrefixes
-      nK: Seq[ByteVector], //nodeKVDBKeys
-      nV: Seq[ByteVector], //nodeKVDBValues
-      lP: Seq[ByteVector], //leafPrefixes
-      lV: Seq[ByteVector]  //leafValues (it's ptr for datastore)
+      nPrefixes: Seq[ByteVector],
+      nKeys: Seq[ByteVector],
+      nValues: Seq[ByteVector],
+      lPrefixes: Seq[ByteVector],
+      lValues: Seq[ByteVector]
   )
 
   /**
-    * Which data is need to export?
+    * Settings for [[ExportData]]
+    *
+    * If false - data will not be exported.
     */
   final case class ExportDataSettings(
-      expNP: Boolean,
-      expNK: Boolean,
-      expNV: Boolean,
-      expLP: Boolean,
-      expLV: Boolean
+      flagNPrefixes: Boolean,
+      flagNKeys: Boolean,
+      flagNValues: Boolean,
+      flagLPrefixes: Boolean,
+      flagLValues: Boolean
   )
 
   /**
     * Sequential export algorithm
-    * returns the data and prefix of the last processed item.
-    * If all bonds in the tree are processed, returns None as prefix
+    *
+    * @param rootHash Root node hash, starting point
+    * @param lastPrefix Describes the path of root to last processed element (if None - start from root)
+    * @param skipSize Describes how many elements to skip
+    * @param takeSize Describes how many elements to take
+    * @param getNodeDataFromStore Function to getng data from storage
+    * @param settings [[ExportDataSettings]]
+    *
+    * @return
+    * Return the data and prefix of the last processed item.
+    * If all bonds in the tree are processed, returns None as prefix.
+    * {{{
+    * prefix - Prefix that describes the path of root to node
+    * decoded - Deserialized data (from parsing)
+    * lastItemIndex - Last processed item number
+    * }}}
     */
-  def sequentialExport[F[_]: Monad](
+  def sequentialExport[F[_]: Sync](
       rootHash: ByteVector,
-      lastPrefix: Option[ByteVector], //describes the path of root to last processed element (if None - start from root)
-      skipSize: Int,                  //how many elements to skip
-      takeSize: Int,                  //how many elements to take
+      lastPrefix: Option[ByteVector],
+      skipSize: Int,
+      takeSize: Int,
       getNodeDataFromStore: ByteVector => F[Option[ByteVector]],
-      settings: ExportDataSettings,
-      countableItem: CountableItem = calculateNodes //don't used (will be use in the future)
+      settings: ExportDataSettings
   ): F[(ExportData, Option[ByteVector])] = {
     final case class NodeData(
-        prefix: ByteVector,         //a prefix that describes the path of root to node
-        decoded: Node,              //deserialized data (from parsing)
-        lastItemIndex: Option[Byte] //last processed item number
+        prefix: ByteVector,
+        decoded: Node,
+        lastItemIndex: Option[Byte]
     )
-    type Path = Vector[NodeData] //sequence used in recursions
+    type Path = Vector[NodeData] // Sequence used in recursions
+
+    final case class NodePathData(
+        nodeHash: ByteVector,   // Hash of node for load
+        nodePrefix: ByteVector, // Prefix of this node
+        restPrefix: ByteVector, // Prefix that describes the rest of the Path
+        path: Path              // Return path
+    )
 
     /**
       * Create path from root to lastPrefix node
       */
-    final case class NodePathData(
-        nodeHash: ByteVector,   //hash of node for load
-        nodePrefix: ByteVector, //prefix of this node
-        restPrefix: ByteVector, //a prefix that describes the rest of the Path
-        path: Path              //return path
-    )
     def initNodePath(
         params: NodePathData
     ): F[Either[NodePathData, Path]] =
@@ -261,133 +324,137 @@ object RadixTreeWithExternReadCache {
         case NodePathData(hash, nodePrefix, tempPrefix, path) =>
           for {
             nodeOpt <- getNodeDataFromStore(hash)
-            decoded = {
-              assert(nodeOpt.isDefined, s"Export error: Node with key ${hash.toHex} not found")
-              val node = nodeOpt.get
-              codecs.decode(node)
-            }
+            node <- nodeOpt.liftTo[F](
+                     new Exception(s"Export error: node with key ${hash.toHex} not found.")
+                   )
+            decodedNode = Codecs.decode(node)
             r = if (tempPrefix.isEmpty)
-              (NodeData(nodePrefix, decoded, none) +: path).asRight //happy end
-            else                                                    //go dipper
-              decoded(byteToInt(tempPrefix.head)) match {
+              (NodeData(nodePrefix, decodedNode, none) +: path).asRight // Happy end
+            else                                                        // Go dipper
+              decodedNode(byteToInt(tempPrefix.head)) match {
                 case NodePtr(ptrPrefix, ptr) =>
                   val (prefixCommon, prefixRest, ptrPrefixRest) =
                     commonPrefix(tempPrefix.tail, ptrPrefix)
                   assert(
                     ptrPrefixRest.isEmpty,
-                    s"Export error: Node with prefix ${(nodePrefix ++ tempPrefix).toHex} not found"
+                    s"Export error: node with prefix ${(nodePrefix ++ tempPrefix).toHex} not found."
                   )
                   NodePathData(
                     ptr,
                     (nodePrefix :+ tempPrefix.head) ++ prefixCommon,
                     prefixRest,
-                    NodeData(nodePrefix, decoded, tempPrefix.head.some) +: path
+                    NodeData(nodePrefix, decodedNode, tempPrefix.head.some) +: path
                   ).asLeft
                 case _ =>
                   assert(
                     assertion = false,
-                    s"Export error: Node with prefix ${(nodePrefix ++ tempPrefix).toHex} not found"
+                    s"Export error: node with prefix ${(nodePrefix ++ tempPrefix).toHex} not found."
                   )
-                  Vector().asRight //Not found
+                  Vector().asRight // Not found
               }
           } yield r
       }
 
-    /**
-      * Main loop
-      */
     type LoopData = (
-        Path,       // path of node from current to root
+        Path,       // Path of node from current to root
         (Int, Int), // Skip & take counter
         ExportData  // Result of export
     )
-    def loop(params: LoopData): F[Either[LoopData, (ExportData, Option[ByteVector])]] = {
+
+    /**
+      * Find next non-empty item.
+      *
+      * @param node Node to look for
+      * @param lastIdxOpt Last found index (if this node was not searched - [[None]])
+      * @return [[Some]](numItem, [[Item]]) if item found, [[None]] if non-empty item not found
+      */
+    @tailrec
+    def findNextNonEmptyItem(node: Node, lastIdxOpt: Option[Byte]): Option[(Byte, Item)] =
+      if (lastIdxOpt == 0xFF.toByte.some) none
+      else {
+        val curIdxInt = lastIdxOpt.map(byteToInt(_) + 1).getOrElse(0)
+        val curItem   = node(curIdxInt)
+        val curIdx    = curIdxInt.toByte
+        curItem match {
+          case EmptyItem => findNextNonEmptyItem(node, curIdx.some)
+          case Leaf(_, _) =>
+            if (settings.flagLPrefixes || settings.flagLValues) (curIdx, curItem).some
+            else findNextNonEmptyItem(node, curIdx.some)
+          case NodePtr(_, _) => (curIdx, curItem).some
+        }
+      }
+
+    /**
+      * Export one [[Node]] and recursively move to the next. If the Skip counter or take counter is more than 1
+      */
+    def nodeExport(params: LoopData): F[Either[LoopData, (ExportData, Option[ByteVector])]] = {
       val (path, (skip, take), expData) = params
-      if (path.isEmpty) Monad[F].pure((expData, none).asRight) //end of Tree
+      if (path.isEmpty) // End of Tree
+        (expData, Option.empty[ByteVector]).asRight[LoopData].pure
       else {
         val curNodeData   = path.head
         val curNodePrefix = curNodeData.prefix
         val curNode       = curNodeData.decoded
 
         if ((skip, take) == (0, 0))
-          Monad[F].pure((expData, curNodePrefix.some).asRight) //end of skip&take counter
+          (expData, curNodePrefix.some).asRight[LoopData].pure // End of skip&take counter
         else {
-          @tailrec
-          def findNextNotEmptyItem(lastIndexOpt: Option[Byte]): Option[(Byte, Item)] = {
-            def incIndex(index: Byte) =
-              if (index == 0xFF.toByte) none
-              else (byteToInt(index) + 1).toByte.some
-            val curIndexOpt = lastIndexOpt.map(incIndex).getOrElse(0.toByte.some)
-
-            curIndexOpt match {
-              case None => none
-              case Some(curIndex) =>
-                val curItem = curNode(byteToInt(curIndex))
-                curItem match {
-                  case EmptyItem => findNextNotEmptyItem(curIndex.some)
-                  case Leaf(_, _) =>
-                    if (settings.expLP || settings.expLV)
-                      (curIndex, curItem).some
-                    else findNextNotEmptyItem(curIndex.some)
-                  case NodePtr(_, _) => (curIndex, curItem).some
-                }
-            }
-          }
-
-          val nextNotEmptyItem = findNextNotEmptyItem(curNodeData.lastItemIndex)
+          val nextNotEmptyItem = findNextNonEmptyItem(curNode, curNodeData.lastItemIndex)
           nextNotEmptyItem match {
-            case None => Monad[F].pure((path.tail, (skip, take), expData).asLeft)
+            case None =>
+              (path.tail, (skip, take), expData).asLeft[(ExportData, Option[ByteVector])].pure
             case Some((itemIndex, item)) =>
               val newCurNodeData = NodeData(curNodePrefix, curNode, itemIndex.some)
               val newPath        = newCurNodeData +: path.tail
               item match {
-                case EmptyItem => Monad[F].pure((newPath, (skip, take), expData).asLeft)
+                case EmptyItem =>
+                  (newPath, (skip, take), expData).asLeft[(ExportData, Option[ByteVector])].pure
                 case Leaf(leafPrefix, leafValue) =>
-                  if (skip > 0) Monad[F].pure((newPath, (skip, take), expData).asLeft)
+                  if (skip > 0)
+                    (newPath, (skip, take), expData).asLeft[(ExportData, Option[ByteVector])].pure
                   else {
                     val newLP =
-                      if (settings.expLP) {
+                      if (settings.flagLPrefixes) {
                         val newSingleLP = (curNodePrefix :+ itemIndex) ++ leafPrefix
-                        expData.lP :+ newSingleLP
+                        expData.lPrefixes :+ newSingleLP
                       } else Vector()
                     val newLV =
-                      if (settings.expLV) expData.lV :+ leafValue else Vector()
+                      if (settings.flagLValues) expData.lValues :+ leafValue else Vector()
                     val newExportData = ExportData(
-                      nP = expData.nP,
-                      nK = expData.nK,
-                      nV = expData.nV,
-                      lP = newLP,
-                      lV = newLV
+                      nPrefixes = expData.nPrefixes,
+                      nKeys = expData.nKeys,
+                      nValues = expData.nValues,
+                      lPrefixes = newLP,
+                      lValues = newLV
                     )
-                    Monad[F].pure((newPath, (skip, take), newExportData).asLeft)
+                    (newPath, (skip, take), newExportData)
+                      .asLeft[(ExportData, Option[ByteVector])]
+                      .pure
                   }
 
                 case NodePtr(ptrPrefix, ptr) =>
                   for {
                     childNodeOpt <- getNodeDataFromStore(ptr)
-                    childNV = {
-                      assert(
-                        childNodeOpt.isDefined,
-                        s"Export error: Node with key ${ptr.toHex} not found"
-                      )
-                      childNodeOpt.get
-                    }
-                    childDecoded  = codecs.decode(childNV)
+                    childNV <- childNodeOpt.liftTo[F](
+                                new Exception(s"Export error: Node with key ${ptr.toHex} not found")
+                              )
+                    childDecoded  = Codecs.decode(childNV)
                     childNP       = (curNodePrefix :+ itemIndex) ++ ptrPrefix
                     childNodeData = NodeData(childNP, childDecoded, none)
                     childPath     = childNodeData +: newPath
 
                     r = if (skip > 0) (childPath, (skip - 1, take), expData).asLeft
                     else {
-                      val newNP = if (settings.expNP) expData.nP :+ childNP else Vector()
-                      val newNK = if (settings.expNK) expData.nK :+ ptr else Vector()
-                      val newNV = if (settings.expNV) expData.nV :+ childNV else Vector()
+                      val newNP =
+                        if (settings.flagNPrefixes) expData.nPrefixes :+ childNP else Vector()
+                      val newNK = if (settings.flagNKeys) expData.nKeys :+ ptr else Vector()
+                      val newNV = if (settings.flagNValues) expData.nValues :+ childNV else Vector()
                       val newData = ExportData(
-                        nP = newNP,
-                        nK = newNK,
-                        nV = newNV,
-                        lP = expData.lP,
-                        lV = expData.lV
+                        nPrefixes = newNP,
+                        nKeys = newNK,
+                        nValues = newNV,
+                        lPrefixes = expData.lPrefixes,
+                        lValues = expData.lValues
                       )
                       (childPath, (skip, take - 1), newData).asLeft
                     }
@@ -398,74 +465,69 @@ object RadixTreeWithExternReadCache {
       }
     }
 
-    val rootParams =
-      NodePathData(rootHash, ByteVector.empty, lastPrefix.getOrElse(ByteVector.empty), Vector())
-    val emptyExportData  = ExportData(Vector(), Vector(), Vector(), Vector(), Vector())
-    val emptyExportDataF = emptyExportData.pure
-
     assert(
       (skipSize, takeSize) != (0, 0),
-      s"Export error: invalid initial conditions (skipSize, takeSize)==(0,0)"
+      s"Export error: invalid initial conditions (skipSize, takeSize)==(0,0)."
     )
 
-    val noRootStart  = (emptyExportDataF, skipSize, takeSize)     //start from next node after lastPrefix
-    val skippedStart = (emptyExportDataF, skipSize - 1, takeSize) //skipped node start
-    val rootExportData = for {
-      rootOpt <- getNodeDataFromStore(rootHash)
-      root = {
-        assert(
-          rootOpt.isDefined,
-          s"Export error: root node with key ${rootHash.toHex} not found"
-        )
-        rootOpt.get
-      }
-      newNP = if (settings.expNP) Vector(ByteVector.empty) else Vector()
-      newNK = if (settings.expNK) Vector(rootHash) else Vector()
-      newNV = if (settings.expNV) Vector(root) else Vector()
-    } yield ExportData(newNP, newNK, newNV, Vector(), Vector())
-    val rootStart = (rootExportData, skipSize, takeSize - 1) //take root
+    val emptyExportData = ExportData(Vector(), Vector(), Vector(), Vector(), Vector())
 
-    //defining init data
-    val (initExportDataF, initSkipSize, initTakeSize) = lastPrefix
-      .map(_ => noRootStart)
-      .getOrElse {
-        if (skipSize > 0) skippedStart
-        else rootStart
+    def doExport(rootNodeSer: ByteVector) = {
+      val rootParams =
+        NodePathData(rootHash, ByteVector.empty, lastPrefix.getOrElse(ByteVector.empty), Vector())
+      val noRootStart  = (emptyExportData, skipSize, takeSize)     // Start from next node after lastPrefix
+      val skippedStart = (emptyExportData, skipSize - 1, takeSize) // Skipped node start
+      val rootExportData: ExportData = {
+        val newNP = if (settings.flagNPrefixes) Vector(ByteVector.empty) else Vector()
+        val newNK = if (settings.flagNKeys) Vector(rootHash) else Vector()
+        val newNV = if (settings.flagNValues) Vector(rootNodeSer) else Vector()
+        ExportData(newNP, newNK, newNV, Vector(), Vector())
       }
+      val rootStart = (rootExportData, skipSize, takeSize - 1) // Take root
 
-    val doExport = for {
-      path                  <- rootParams.tailRecM(initNodePath)
-      initExportData        <- initExportDataF
-      startParams: LoopData = (path, (initSkipSize, initTakeSize), initExportData)
-      r                     <- startParams.tailRecM(loop)
-    } yield r
-    val emptyResult = Monad[F].pure((emptyExportData, none))
+      // Defining init data
+      val (initExportData, initSkipSize, initTakeSize) = lastPrefix
+        .as(noRootStart)
+        .getOrElse {
+          if (skipSize > 0) skippedStart
+          else rootStart
+        }
+      for {
+        path                  <- rootParams.tailRecM(initNodePath)
+        startParams: LoopData = (path, (initSkipSize, initTakeSize), initExportData)
+        r                     <- startParams.tailRecM(nodeExport)
+      } yield r
+    }
+
+    val emptyResult = (emptyExportData, none).pure
 
     for {
-      rootNodeOpt <- getNodeDataFromStore(rootHash)
-      r <- if (rootNodeOpt.isDefined) doExport
-          else emptyResult
+      rootNodeSerOpt <- getNodeDataFromStore(rootHash)
+      r              <- rootNodeSerOpt.map(doExport).getOrElse(emptyResult)
     } yield r
   }
 
+  /**
+    * Radix Tree implementation
+    */
   class RadixTreeImpl[F[_]: Sync: Parallel](
       store: KeyValueTypedStore[F, ByteVector, ByteVector],
-      cacheR: LimitTrieMapCache[ByteVector, Node]
-  ) {
+      cacheR: LimitTrieMapCache[ByteVector, Node]) {
 
     /**
       * Load and decode serializing data from KVDB.
       */
     private def loadNodeFromStore(nodePtr: ByteVector): F[Option[Node]] =
-      store.get1(nodePtr).map(_.map(codecs.decode))
+      store.get1(nodePtr).map(_.map(Codecs.decode))
 
     /**
       * Load one node from [[cacheR]].
+      *
       * If there is no such record in cache - load and decode from KVDB, then save to cacheR.
       * If there is no such record in KVDB - execute assert (if set noAssert flag - return emptyNode).
       */
     def loadNode(nodePtr: ByteVector, noAssert: Boolean = false): F[Node] = {
-      def errorMsg(): Unit = assert(noAssert, s"Missing node in database. ptr=${nodePtr.toHex}")
+      def errorMsg(): Unit = assert(noAssert, s"Missing node in database. ptr=${nodePtr.toHex}.")
       val cacheMiss = for {
         storeNodeOpt <- loadNodeFromStore(nodePtr)
         _            = storeNodeOpt.map(cacheR.update(nodePtr, _)).getOrElse(errorMsg())
@@ -478,7 +540,8 @@ object RadixTreeWithExternReadCache {
 
     /**
       * Cache for storing serializing nodes. For subsequent unloading in KVDB
-      * In cache store kv-pair (hash, bytes).
+      *
+      * Cache stores kv-pairs (hash, bytes).
       * Where hash -  Blake2b256Hash of bytes,
       *       bytes - serializing data of nodes.
       */
@@ -486,15 +549,16 @@ object RadixTreeWithExternReadCache {
 
     /**
       * Serializing and hashing one [[Node]].
+      *
       * Serializing data load in [[cacheW]].
       * If detected collision with older cache data - executing assert
       */
     def saveNode(node: Node): ByteVector = {
       val (hash, bytes) = hashNode(node)
-      // collision alarm
+      // Collision alarm
       def generateErrorMsg(v: Node): Unit = assert(
         v == node,
-        s"collision in cache (record with key = ${hash.toHex} has already existed)"
+        s"Collision in cache: record with key = ${hash.toHex} has already existed."
       )
       cacheR.get(hash).map(generateErrorMsg).getOrElse(cacheR.update(hash, node))
       cacheW.update(hash, bytes)
@@ -503,6 +567,7 @@ object RadixTreeWithExternReadCache {
 
     /**
       * Save all cacheW to KVDB
+      *
       * If detected collision with older KVDB data - execute assert
       */
     def commit(): F[Unit] = {
@@ -518,7 +583,7 @@ object RadixTreeWithExternReadCache {
         else {
           assert(
             assertion = false,
-            s"${kvCollision.length} collisions in KVDB (first collision with key = ${kvCollision.head._1.toHex})"
+            s"${kvCollision.length} collisions in KVDB (first collision with key = ${kvCollision.head._1.toHex})."
           )
           List.empty
         }
@@ -538,26 +603,27 @@ object RadixTreeWithExternReadCache {
       type Params = (Node, ByteVector)
       def loop(params: Params): F[Either[Params, Option[ByteVector]]] =
         params match {
-          case (_, ByteVector.empty) => Sync[F].pure(none.asRight) //Not found
+          case (_, ByteVector.empty) => Option.empty[ByteVector].asRight[Params].pure // Not found
           case (curNode, prefix) =>
             curNode(byteToInt(prefix.head)) match {
-              case EmptyItem => Sync[F].pure(none.asRight) //Not found
+              case EmptyItem => Option.empty[ByteVector].asRight[Params].pure // Not found
 
               case Leaf(leafPrefix, value) =>
-                if (leafPrefix == prefix.tail) Sync[F].pure(value.some.asRight) //Happy end
-                else Sync[F].pure(none.asRight)                                 //Not found
+                if (leafPrefix == prefix.tail) value.some.asRight[Params].pure // Happy end
+                else Option.empty[ByteVector].asRight[Params].pure             // Not found
 
               case NodePtr(ptrPrefix, ptr) =>
                 val (_, prefixRest, ptrPrefixRest) = commonPrefix(prefix.tail, ptrPrefix)
-                if (ptrPrefixRest.isEmpty) loadNode(ptr).map(n => (n, prefixRest).asLeft) //Deeper
-                else Sync[F].pure(none.asRight)                                           //Not found
+                if (ptrPrefixRest.isEmpty) loadNode(ptr).map(n => (n, prefixRest).asLeft) // Deeper
+                else Option.empty[ByteVector].asRight[Params].pure                        // Not found
             }
         }
-      Sync[F].tailRecM(startNode, startPrefix)(loop)
+      (startNode, startPrefix).tailRecM(loop)
     }
 
     /**
       * Create node from [[Item]].
+      *
       * If item is NodePtr and prefix is empty - load child node
       */
     private def createNodeFromItem(item: Item): F[Node] =
@@ -586,8 +652,8 @@ object RadixTreeWithExternReadCache {
       if (compaction) {
         val nonEmptyItems = node.iterator.filter(_ != EmptyItem).take(2).toList
         nonEmptyItems.size match {
-          case 0 => EmptyItem //all items are empty
-          case 1 => //only one item is not empty - merge child and parent nodes
+          case 0 => EmptyItem // All items are empty.
+          case 1 => // Only one item is not empty - merge child and parent nodes.
             val idxItem = node.indexOf(nonEmptyItems.head)
             nonEmptyItems.head match {
               case EmptyItem => EmptyItem
@@ -596,16 +662,18 @@ object RadixTreeWithExternReadCache {
               case NodePtr(nodePtrPrefix, ptr) =>
                 NodePtr(prefix ++ ByteVector(idxItem) ++ nodePtrPrefix, ptr)
             }
-          case 2 => //2 or more items are not empty
+          case 2 => // 2 or more items are not empty.
             NodePtr(prefix, saveNode(node))
         }
       } else NodePtr(prefix, saveNode(node))
 
     /**
       * Save new leaf value to this part of tree (start from curItems).
-      * Rehash and save all depend node to cacheW. Return updated curItems.
+      * Rehash and save all depend node to [[cacheW]].
+      *
       * If exist leaf with same prefix but different value - update leaf value.
       * If exist leaf with same prefix and same value - return [[None]].
+      * @return Updated current item.
       */
     def update(
         curItem: Item,
@@ -614,17 +682,17 @@ object RadixTreeWithExternReadCache {
     ): F[Option[Item]] =
       curItem match {
         case EmptyItem =>
-          (Leaf(insPrefix, insValue): Item).some.pure //update EmptyItem to Leaf
+          (Leaf(insPrefix, insValue): Item).some.pure // Update EmptyItem to Leaf.
 
         case Leaf(leafPrefix, leafValue) =>
-          assert(leafPrefix.size == insPrefix.size, "All Radix keys should be same length")
+          assert(leafPrefix.size == insPrefix.size, "All Radix keys should be same length.")
           if (leafPrefix == insPrefix) {
             if (insValue == leafValue) none[Item].pure
             else (Leaf(insPrefix, insValue): Item).some.pure
-          } //update Leaf
+          } // Update Leaf.
           else {
-            // Create child node, insert existing and new leaf in this node
-            // intentionally not recursive for speed up
+            // Create child node, insert existing and new leaf in this node.
+            // Intentionally not recursive for speed up.
             val (commPrefix, insPrefixRest, leafPrefixRest) = commonPrefix(insPrefix, leafPrefix)
             val newNode = emptyNode
               .updated(byteToInt(leafPrefixRest.head), Leaf(leafPrefixRest.tail, leafValue))
@@ -633,22 +701,22 @@ object RadixTreeWithExternReadCache {
           }
 
         case NodePtr(ptrPrefix, ptr) =>
-          assert(ptrPrefix.size < insPrefix.size, "Radix key should be longer than NodePtr key")
+          assert(ptrPrefix.size < insPrefix.size, "Radix key should be longer than NodePtr key.")
           val (commPrefix, insPrefixRest, ptrPrefixRest) = commonPrefix(insPrefix, ptrPrefix)
           if (ptrPrefixRest.isEmpty) {
             val (childItemIdx, childInsPrefix) =
               (byteToInt(insPrefixRest.head), insPrefixRest.tail)
-            //add new node to existing child node
+            // Add new node to existing child node.
             for {
               childNode    <- loadNode(ptr)
-              childItemOpt <- update(childNode(childItemIdx), childInsPrefix, insValue) //deeper
+              childItemOpt <- update(childNode(childItemIdx), childInsPrefix, insValue) // Deeper
               returnedItem = childItemOpt.map { childItem =>
                 val updatedChildNode = childNode.updated(childItemIdx, childItem)
                 saveNodeAndCreateItem(updatedChildNode, commPrefix, compaction = false)
               }
             } yield returnedItem
           } else {
-            // Create child node, insert existing Ptr and new leaf in this node
+            // Create child node, insert existing Ptr and new leaf in this node.
             val newNode = emptyNode
               .updated(byteToInt(ptrPrefixRest.head), NodePtr(ptrPrefixRest.tail, ptr))
               .updated(byteToInt(insPrefixRest.head), Leaf(insPrefixRest.tail, insValue))
@@ -658,26 +726,28 @@ object RadixTreeWithExternReadCache {
 
     /**
       * Delete leaf value from this part of tree (start from curItem).
-      * Rehash and save all depend node to cacheW. Return updated curItem.
+      * Rehash and save all depend node to cacheW.
+      *
       * If not found leaf with  delPrefix - return [[None]].
+      * @return Updated current item.
       */
     def delete(curItem: Item, delPrefix: ByteVector): F[Option[Item]] =
       curItem match {
-        case EmptyItem => none[Item].pure //Not found
+        case EmptyItem => none[Item].pure // Not found
 
         case Leaf(leafPrefix, _) =>
-          if (leafPrefix == delPrefix) (EmptyItem: Item).some.pure //Happy end
-          else none[Item].pure                                     //Not found
+          if (leafPrefix == delPrefix) (EmptyItem: Item).some.pure // Happy end
+          else none[Item].pure                                     // Not found
 
         case NodePtr(ptrPrefix, ptr) =>
           val (commPrefix, delPrefixRest, ptrPrefixRest) = commonPrefix(delPrefix, ptrPrefix)
-          if (ptrPrefixRest.nonEmpty || delPrefixRest.isEmpty) none[Item].pure //Not found
+          if (ptrPrefixRest.nonEmpty || delPrefixRest.isEmpty) none[Item].pure // Not found
           else {
             val (childItemIdx, childDelPrefix) =
               (byteToInt(delPrefixRest.head), delPrefixRest.tail)
             for {
               childNode    <- loadNode(ptr)
-              childItemOpt <- delete(childNode(childItemIdx), childDelPrefix) //deeper
+              childItemOpt <- delete(childNode(childItemIdx), childDelPrefix) // Deeper
               returnedChild = childItemOpt.map { childItem =>
                 saveNodeAndCreateItem(childNode.updated(childItemIdx, childItem), commPrefix)
               }
@@ -686,24 +756,27 @@ object RadixTreeWithExternReadCache {
       }
 
     /**
-      * Parallel processing of HistoryActions in this part of tree (start from curNode).
+      * Parallel processing of [[HistoryAction]]s in this part of tree (start from curNode).
+      *
       * New data load to [[cacheW]].
-      * Return updated curNode. if no action was taken - return [[None]].
+      * @return Updated curNode. if no action was taken - return [[None]].
       */
     def makeActions(curNode: Node, curActions: List[HistoryAction]): F[Option[Node]] = {
+      // Group the actions by the first byte of the prefix.
       val groups = curActions
-        .groupBy( //fixme
-          _.key.headOption.getOrElse({
-            assert(assertion = false, "The length of all prefixes in the subtree must be the same")
-            0x00.toByte
-          })
-        )
+        .groupBy(_.key.headOption.getOrElse {
+          assert(assertion = false, "The length of all prefixes in the subtree must be the same.")
+          0x00.toByte // TODO: Need rewrite this place without unused constant
+        })
         .toList
+      // Process actions within each group.
       val newGroupItemsF = groups.map {
         case (groupIdx, groupActions) =>
           val index = byteToInt(groupIdx)
           val item  = curNode(index)
           if (groupActions.length == 1) {
+            // If we have 1 action in group.
+            // We can't parallel next and we should use sequential traversing with help update() or delete().
             val newItem = groupActions.head match {
               case InsertAction(key, hash) =>
                 update(item, ByteVector(key).tail, hash.bytes)
@@ -711,6 +784,7 @@ object RadixTreeWithExternReadCache {
             }
             newItem.map((index, _))
           } else {
+            // If we have more than 1 action. We can create more parallel processes.
             val notExistInsertAction = groupActions.collectFirst { case _: InsertAction => true }.isEmpty
             val clearGroupActions =
               if (item == EmptyItem && notExistInsertAction) groupActions.collect {
@@ -730,17 +804,21 @@ object RadixTreeWithExternReadCache {
             }
           }
       }
+
       for {
+        // Process actions within each group.
         newGroupItems <- newGroupItemsF.parSequence
+        // Update all changed items in current node.
         newCurNode = newGroupItems.foldLeft(curNode) {
           case (tempNode, (index, newItemOpt)) =>
             newItemOpt.map(tempNode.updated(index, _)).getOrElse(tempNode)
         }
-      } yield if (newCurNode != curNode) newCurNode.some else none
+      } // If current node changing return new node, otherwise return none.
+      yield if (newCurNode != curNode) newCurNode.some else none
     }
 
     /**
-      * Pretty print radix tree
+      * Pretty printer for Radix tree
       */
     final def print(curNode: Node, indentLevel: Int = 0): Unit = {
       val indent               = Seq.fill(indentLevel * 2)(" ").mkString

--- a/rspace/src/main/scala/coop/rchain/rspace/history/RadixTreeWithExternReadCache.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/history/RadixTreeWithExternReadCache.scala
@@ -10,7 +10,7 @@ import scodec.bits.ByteVector
 import scala.annotation.tailrec
 import scala.collection.concurrent.TrieMap
 
-object RadixTree {
+object RadixTreeWithExternReadCache {
 
   /**
     * Described items which contain in [[Node]].

--- a/rspace/src/main/scala/coop/rchain/rspace/history/RadixTreeWithExternReadCache.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/history/RadixTreeWithExternReadCache.scala
@@ -1,0 +1,760 @@
+package coop.rchain.rspace.history
+
+import cats.effect.Sync
+import cats.syntax.all._
+import cats.{Monad, Parallel}
+import coop.rchain.shared.syntax._
+import coop.rchain.store.KeyValueTypedStore
+import scodec.bits.ByteVector
+
+import scala.annotation.tailrec
+import scala.collection.concurrent.TrieMap
+
+/**
+  * Radix Tree implementation
+  */
+object RadixTreeWithExternReadCache {
+
+  /**
+    * Node structure (EmptyItem, Leaf and NodePointer)
+    * There is only one type of element in Tree [[Node]] = Vector[Item]
+    */
+  sealed trait Item
+  final case object EmptyItem                                   extends Item
+  final case class Leaf(prefix: ByteVector, value: ByteVector)  extends Item
+  final case class NodePtr(prefix: ByteVector, ptr: ByteVector) extends Item
+
+  type Node = Vector[Item]
+
+  /**
+    * number of items always constant
+    */
+  val numItems = 256
+
+  /**
+    * Empty node consists only of [[EmptyItem]]'s
+    */
+  val emptyNode: Node = (0 until numItems).map(_ => EmptyItem).toVector
+
+  /**
+    * Binary codecs for serializing/deserializing Node in Radix tree
+    * Coding structure for items:
+    *   EmptyItem                   - Empty (not encode)
+
+    *   Leaf(prefix,value)    -> [item number] [second byte] [prefix0]..[prefixM] [value0]..[value31]
+    *                               where is: [second byte] -> bit7 = 0 (Leaf identifier)
+    *                                                          bit6..bit0 - prefix length = M (from 0 to 127)
+    *
+    *   NodePtr(prefix,ptr)   -> [item number] [second byte] [prefix0]..[prefixM] [ptr0]..[ptr31]
+    *                               where is: [second byte] -> bit7 = 1 (NodePtr identifier)
+    *                                                          bit6..bit0 - prefix length = M (from 0 to 127)
+    */
+  object codecs {
+    private val defSize  = 32
+    private val headSize = 2 //2 bytes: first - item number, second - second byte
+
+    def encode(node: Node): ByteVector = {
+      //calculating size of buffer
+      val sizeNode = node.size
+
+      @tailrec
+      def loopSize(index: Int, size: Int): Int =
+        if (sizeNode > index)
+          node(index) match {
+            case EmptyItem => loopSize(index + 1, size)
+
+            case Leaf(leafPrefix, value) =>
+              val sizePrefix = leafPrefix.size.toInt
+              assert(sizePrefix <= 127, "error during serialization (size of prefix more than 127)")
+              assert(
+                value.size == defSize,
+                "error during serialization (size of leafValue not equal 32)"
+              )
+              loopSize(index + 1, size + headSize + sizePrefix + defSize)
+
+            case NodePtr(ptrPrefix, ptr) =>
+              val sizePrefix = ptrPrefix.size.toInt
+              assert(sizePrefix <= 127, "error during serialization (size of prefix more than 127)")
+              assert(
+                ptr.size == defSize,
+                "error during serialization (size of ptrPrefix not equal 32)"
+              )
+              loopSize(index + 1, size + headSize + sizePrefix + defSize)
+          } else size
+
+      val size = loopSize(0, 0)
+      //put in the buffer
+
+      val arr = new Array[Byte](size)
+      @tailrec
+      def loopFill(numItem: Int, idx0: Int): Array[Byte] =
+        if (idx0 == size) arr
+        else {
+          node(numItem) match {
+            case EmptyItem => loopFill(numItem + 1, idx0)
+
+            case Leaf(prefix, value) =>
+              arr(idx0) = numItem.toByte
+              val idxSecondByte   = idx0 + 1
+              val idxPrefixStart  = idxSecondByte + 1
+              val prefixSize: Int = prefix.size.toInt
+              //size & 01111111b
+              arr(idxSecondByte) = (prefixSize & 0x7F).toByte //second byte - type and size of prefix
+              for (i <- 0 until prefixSize) arr(idxPrefixStart + i) = prefix(i.toLong)
+              val idxValueStart = idxPrefixStart + prefixSize
+              for (i <- 0 until defSize) arr(idxValueStart + i) = value(i.toLong)
+              loopFill(numItem + 1, idxValueStart + defSize)
+            case NodePtr(prefix, ptr) =>
+              arr(idx0) = numItem.toByte
+              val idxSecondByte   = idx0 + 1
+              val prefixSize: Int = prefix.size.toInt
+              //10000000b | (size & 01111111b)
+              arr(idxSecondByte) = (0x80 | (prefixSize & 0x7F)).toByte //second byte - type and size of prefix
+              val idxPrefixStart = idxSecondByte + 1
+              for (i <- 0 until prefixSize) arr(idxPrefixStart + i) = prefix(i.toLong)
+              val idxPtrStart = idxPrefixStart + prefixSize
+              for (i <- 0 until defSize) arr(idxPtrStart + i) = ptr(i.toLong)
+              loopFill(numItem + 1, idxPtrStart + defSize)
+          }
+        }
+      ByteVector(loopFill(0, 0))
+    }
+
+    def decode(bv: ByteVector): Node = {
+      val arr     = bv.toArray
+      val maxSize = arr.length
+      @tailrec
+      def loop(idx0: Int, node: Node): Node =
+        if (idx0 == maxSize) node
+        else {
+          val (idx0Next, nodeNext) = try {
+            val numItem: Int = byteToInt(arr(idx0))
+            assert(
+              node(numItem) == EmptyItem,
+              "error during deserialization (wrong number of item)"
+            )
+            val idx1       = idx0 + 1
+            val secondByte = arr(idx1)
+
+            val prefixSize: Int = secondByte & 0x7F
+            val prefix          = new Array[Byte](prefixSize)
+            val idxPrefixStart  = idx1 + 1
+            for (i <- 0 until prefixSize) prefix(i) = arr(idxPrefixStart + i)
+            val valOrPtr         = new Array[Byte](defSize)
+            val idxValOrPtrStart = idxPrefixStart + prefixSize
+            for (i <- 0 until defSize) valOrPtr(i) = arr(idxValOrPtrStart + i)
+            val idx0Next = idxValOrPtrStart + defSize
+            val item = if ((secondByte & 0x80) == 0x00) { //Leaf
+              Leaf(ByteVector(prefix), ByteVector(valOrPtr))
+            } else { //NodePtr
+              NodePtr(ByteVector(prefix), ByteVector(valOrPtr))
+            }
+            (idx0Next, node.updated(numItem, item))
+          } catch {
+            case _: Exception =>
+              assert(assertion = false, "error during deserialization (out of range)")
+              (maxSize, emptyNode)
+          }
+          loop(idx0Next, nodeNext)
+        }
+      loop(0, emptyNode)
+    }
+  }
+
+  /**
+    * Find the common part of b1 and b2.
+    * Return (Common part , rest of b1, rest of b2).
+    */
+  def commonPrefix(b1: ByteVector, b2: ByteVector): (ByteVector, ByteVector, ByteVector) = {
+    @tailrec
+    def go(
+        common: ByteVector,
+        l: ByteVector,
+        r: ByteVector
+    ): (ByteVector, ByteVector, ByteVector) =
+      if (r.isEmpty) {
+        (common, l, r)
+      } else {
+        val lHead = l.head
+        val rHead = r.head
+        if (lHead == rHead) go(common :+ lHead, l.tail, r.tail)
+        else (common, l, r)
+      }
+    go(ByteVector.empty, b1, b2)
+  }
+
+  /**
+    * Hashing serial data.
+    * Return Blake2b256 hash of input data
+    */
+  def hashNode(node: Node): (ByteVector, ByteVector) = {
+    import coop.rchain.crypto.hash.Blake2b256
+    val bytes = codecs.encode(node)
+    (ByteVector(Blake2b256.hash(bytes)), bytes)
+  }
+
+  def byteToInt(b: Byte): Int = b & 0xff
+
+  /**
+    * Which element counts the skip&take counter?
+    */
+  sealed trait CountableItem
+  final case object calculateNodes extends CountableItem
+  final case object calculateLeafs extends CountableItem
+
+  /**
+    * Data for return
+    */
+  final case class ExportData(
+      nP: Seq[ByteVector], //nodePrefixes
+      nK: Seq[ByteVector], //nodeKVDBKeys
+      nV: Seq[ByteVector], //nodeKVDBValues
+      lP: Seq[ByteVector], //leafPrefixes
+      lV: Seq[ByteVector]  //leafValues (it's ptr for datastore)
+  )
+
+  /**
+    * Which data is need to export?
+    */
+  final case class ExportDataSettings(
+      expNP: Boolean,
+      expNK: Boolean,
+      expNV: Boolean,
+      expLP: Boolean,
+      expLV: Boolean
+  )
+
+  /**
+    * Sequential export algorithm
+    * returns the data and prefix of the last processed item.
+    * If all bonds in the tree are processed, returns None as prefix
+    */
+  def sequentialExport[F[_]: Monad](
+      rootHash: ByteVector,
+      lastPrefix: Option[ByteVector], //describes the path of root to last processed element (if None - start from root)
+      skipSize: Int,                  //how many elements to skip
+      takeSize: Int,                  //how many elements to take
+      getNodeDataFromStore: ByteVector => F[Option[ByteVector]],
+      settings: ExportDataSettings,
+      countableItem: CountableItem = calculateNodes //don't used (will be use in the future)
+  ): F[(ExportData, Option[ByteVector])] = {
+    final case class NodeData(
+        prefix: ByteVector,         //a prefix that describes the path of root to node
+        decoded: Node,              //deserialized data (from parsing)
+        lastItemIndex: Option[Byte] //last processed item number
+    )
+    type Path = Vector[NodeData] //sequence used in recursions
+
+    /**
+      * Create path from root to lastPrefix node
+      */
+    final case class NodePathData(
+        nodeHash: ByteVector,   //hash of node for load
+        nodePrefix: ByteVector, //prefix of this node
+        restPrefix: ByteVector, //a prefix that describes the rest of the Path
+        path: Path              //return path
+    )
+    def initNodePath(
+        params: NodePathData
+    ): F[Either[NodePathData, Path]] =
+      params match {
+        case NodePathData(hash, nodePrefix, tempPrefix, path) =>
+          for {
+            nodeOpt <- getNodeDataFromStore(hash)
+            decoded = {
+              assert(nodeOpt.isDefined, s"Export error: Node with key ${hash.toHex} not found")
+              val node = nodeOpt.get
+              codecs.decode(node)
+            }
+            r = if (tempPrefix.isEmpty)
+              (NodeData(nodePrefix, decoded, none) +: path).asRight //happy end
+            else                                                    //go dipper
+              decoded(byteToInt(tempPrefix.head)) match {
+                case NodePtr(ptrPrefix, ptr) =>
+                  val (prefixCommon, prefixRest, ptrPrefixRest) =
+                    commonPrefix(tempPrefix.tail, ptrPrefix)
+                  assert(
+                    ptrPrefixRest.isEmpty,
+                    s"Export error: Node with prefix ${(nodePrefix ++ tempPrefix).toHex} not found"
+                  )
+                  NodePathData(
+                    ptr,
+                    (nodePrefix :+ tempPrefix.head) ++ prefixCommon,
+                    prefixRest,
+                    NodeData(nodePrefix, decoded, tempPrefix.head.some) +: path
+                  ).asLeft
+                case _ =>
+                  assert(
+                    assertion = false,
+                    s"Export error: Node with prefix ${(nodePrefix ++ tempPrefix).toHex} not found"
+                  )
+                  Vector().asRight //Not found
+              }
+          } yield r
+      }
+
+    /**
+      * Main loop
+      */
+    type LoopData = (
+        Path,       // path of node from current to root
+        (Int, Int), // Skip & take counter
+        ExportData  // Result of export
+    )
+    def loop(params: LoopData): F[Either[LoopData, (ExportData, Option[ByteVector])]] = {
+      val (path, (skip, take), expData) = params
+      if (path.isEmpty) Monad[F].pure((expData, none).asRight) //end of Tree
+      else {
+        val curNodeData   = path.head
+        val curNodePrefix = curNodeData.prefix
+        val curNode       = curNodeData.decoded
+
+        if ((skip, take) == (0, 0))
+          Monad[F].pure((expData, curNodePrefix.some).asRight) //end of skip&take counter
+        else {
+          @tailrec
+          def findNextNotEmptyItem(lastIndexOpt: Option[Byte]): Option[(Byte, Item)] = {
+            def incIndex(index: Byte) =
+              if (index == 0xFF.toByte) none
+              else (byteToInt(index) + 1).toByte.some
+            val curIndexOpt = lastIndexOpt.map(incIndex).getOrElse(0.toByte.some)
+
+            curIndexOpt match {
+              case None => none
+              case Some(curIndex) =>
+                val curItem = curNode(byteToInt(curIndex))
+                curItem match {
+                  case EmptyItem => findNextNotEmptyItem(curIndex.some)
+                  case Leaf(_, _) =>
+                    if (settings.expLP || settings.expLV)
+                      (curIndex, curItem).some
+                    else findNextNotEmptyItem(curIndex.some)
+                  case NodePtr(_, _) => (curIndex, curItem).some
+                }
+            }
+          }
+
+          val nextNotEmptyItem = findNextNotEmptyItem(curNodeData.lastItemIndex)
+          nextNotEmptyItem match {
+            case None => Monad[F].pure((path.tail, (skip, take), expData).asLeft)
+            case Some((itemIndex, item)) =>
+              val newCurNodeData = NodeData(curNodePrefix, curNode, itemIndex.some)
+              val newPath        = newCurNodeData +: path.tail
+              item match {
+                case EmptyItem => Monad[F].pure((newPath, (skip, take), expData).asLeft)
+                case Leaf(leafPrefix, leafValue) =>
+                  if (skip > 0) Monad[F].pure((newPath, (skip, take), expData).asLeft)
+                  else {
+                    val newLP =
+                      if (settings.expLP) {
+                        val newSingleLP = (curNodePrefix :+ itemIndex) ++ leafPrefix
+                        expData.lP :+ newSingleLP
+                      } else Vector()
+                    val newLV =
+                      if (settings.expLV) expData.lV :+ leafValue else Vector()
+                    val newExportData = ExportData(
+                      nP = expData.nP,
+                      nK = expData.nK,
+                      nV = expData.nV,
+                      lP = newLP,
+                      lV = newLV
+                    )
+                    Monad[F].pure((newPath, (skip, take), newExportData).asLeft)
+                  }
+
+                case NodePtr(ptrPrefix, ptr) =>
+                  for {
+                    childNodeOpt <- getNodeDataFromStore(ptr)
+                    childNV = {
+                      assert(
+                        childNodeOpt.isDefined,
+                        s"Export error: Node with key ${ptr.toHex} not found"
+                      )
+                      childNodeOpt.get
+                    }
+                    childDecoded  = codecs.decode(childNV)
+                    childNP       = (curNodePrefix :+ itemIndex) ++ ptrPrefix
+                    childNodeData = NodeData(childNP, childDecoded, none)
+                    childPath     = childNodeData +: newPath
+
+                    r = if (skip > 0) (childPath, (skip - 1, take), expData).asLeft
+                    else {
+                      val newNP = if (settings.expNP) expData.nP :+ childNP else Vector()
+                      val newNK = if (settings.expNK) expData.nK :+ ptr else Vector()
+                      val newNV = if (settings.expNV) expData.nV :+ childNV else Vector()
+                      val newData = ExportData(
+                        nP = newNP,
+                        nK = newNK,
+                        nV = newNV,
+                        lP = expData.lP,
+                        lV = expData.lV
+                      )
+                      (childPath, (skip, take - 1), newData).asLeft
+                    }
+                  } yield r
+              }
+          }
+        }
+      }
+    }
+
+    val rootParams =
+      NodePathData(rootHash, ByteVector.empty, lastPrefix.getOrElse(ByteVector.empty), Vector())
+    val emptyExportData  = ExportData(Vector(), Vector(), Vector(), Vector(), Vector())
+    val emptyExportDataF = emptyExportData.pure
+
+    assert(
+      (skipSize, takeSize) != (0, 0),
+      s"Export error: invalid initial conditions (skipSize, takeSize)==(0,0)"
+    )
+
+    val noRootStart  = (emptyExportDataF, skipSize, takeSize)     //start from next node after lastPrefix
+    val skippedStart = (emptyExportDataF, skipSize - 1, takeSize) //skipped node start
+    val rootExportData = for {
+      rootOpt <- getNodeDataFromStore(rootHash)
+      root = {
+        assert(
+          rootOpt.isDefined,
+          s"Export error: root node with key ${rootHash.toHex} not found"
+        )
+        rootOpt.get
+      }
+      newNP = if (settings.expNP) Vector(ByteVector.empty) else Vector()
+      newNK = if (settings.expNK) Vector(rootHash) else Vector()
+      newNV = if (settings.expNV) Vector(root) else Vector()
+    } yield ExportData(newNP, newNK, newNV, Vector(), Vector())
+    val rootStart = (rootExportData, skipSize, takeSize - 1) //take root
+
+    //defining init data
+    val (initExportDataF, initSkipSize, initTakeSize) = lastPrefix
+      .map(_ => noRootStart)
+      .getOrElse {
+        if (skipSize > 0) skippedStart
+        else rootStart
+      }
+
+    val doExport = for {
+      path                  <- rootParams.tailRecM(initNodePath)
+      initExportData        <- initExportDataF
+      startParams: LoopData = (path, (initSkipSize, initTakeSize), initExportData)
+      r                     <- startParams.tailRecM(loop)
+    } yield r
+    val emptyResult = Monad[F].pure((emptyExportData, none))
+
+    for {
+      rootNodeOpt <- getNodeDataFromStore(rootHash)
+      r <- if (rootNodeOpt.isDefined) doExport
+          else emptyResult
+    } yield r
+  }
+
+  class RadixTreeImpl[F[_]: Sync: Parallel](
+      store: KeyValueTypedStore[F, ByteVector, ByteVector],
+      cacheR: LimitTrieMapCache[ByteVector, Node]
+  ) {
+
+    /**
+      * Load and decode serializing data from KVDB.
+      */
+    private def loadNodeFromStore(nodePtr: ByteVector): F[Option[Node]] =
+      store.get1(nodePtr).map(_.map(codecs.decode))
+
+    /**
+      * Load one node from [[cacheR]].
+      * If there is no such record in cache - load and decode from KVDB, then save to cacheR.
+      * If there is no such record in KVDB - execute assert (if set noAssert flag - return emptyNode).
+      */
+    def loadNode(nodePtr: ByteVector, noAssert: Boolean = false): F[Node] = {
+      def errorMsg(): Unit = assert(noAssert, s"Missing node in database. ptr=${nodePtr.toHex}")
+      val cacheMiss = for {
+        storeNodeOpt <- loadNodeFromStore(nodePtr)
+        _            = storeNodeOpt.map(cacheR.update(nodePtr, _)).getOrElse(errorMsg())
+      } yield storeNodeOpt.getOrElse(emptyNode)
+      for {
+        cacheNodeOpt <- Sync[F].delay(cacheR.get(nodePtr))
+        res          <- cacheNodeOpt.map(_.pure).getOrElse(cacheMiss)
+      } yield res
+    }
+
+    /**
+      * Cache for storing serializing nodes. For subsequent unloading in KVDB
+      * In cache store kv-pair (hash, bytes).
+      * Where hash -  Blake2b256Hash of bytes,
+      *       bytes - serializing data of nodes.
+      */
+    private val cacheW: TrieMap[ByteVector, ByteVector] = TrieMap.empty
+
+    /**
+      * Serializing and hashing one [[Node]].
+      * Serializing data load in [[cacheW]].
+      * If detected collision with older cache data - executing assert
+      */
+    def saveNode(node: Node): ByteVector = {
+      val (hash, bytes) = hashNode(node)
+      // collision alarm
+      def generateErrorMsg(v: Node): Unit = assert(
+        v == node,
+        s"collision in cache (record with key = ${hash.toHex} has already existed)"
+      )
+      cacheR.get(hash).map(generateErrorMsg).getOrElse(cacheR.update(hash, node))
+      cacheW.update(hash, bytes)
+      hash
+    }
+
+    /**
+      * Save all cacheW to KVDB
+      * If detected collision with older KVDB data - execute assert
+      */
+    def commit(): F[Unit] = {
+      val kvPairs = cacheW.toList
+      for {
+        ifAbsent          <- store.contains(kvPairs.map(_._1))
+        kvIfAbsent        = kvPairs zip ifAbsent
+        kvExist           = kvIfAbsent.filter(_._2).map(_._1)
+        valueExistInStore <- store.get(kvExist.map(_._1))
+        kvvExist          = kvExist zip valueExistInStore.map(_.getOrElse(ByteVector.empty))
+        kvCollision       = kvvExist.filter(kvv => !(kvv._1._2 == kvv._2)).map(_._1)
+        kvAbsent = if (kvCollision.isEmpty) kvIfAbsent.filterNot(_._2).map(_._1)
+        else {
+          assert(
+            assertion = false,
+            s"${kvCollision.length} collisions in KVDB (first collision with key = ${kvCollision.head._1.toHex})"
+          )
+          List.empty
+        }
+        _ <- store.put(kvAbsent)
+      } yield ()
+    }
+
+    /**
+      * Clear [[cacheW]] (cache for storing data to write in KVDB).
+      */
+    def clearWriteCache(): Unit = cacheW.clear()
+
+    /**
+      * Read leaf data with prefix. If data not found, returned [[None]]
+      */
+    final def read(startNode: Node, startPrefix: ByteVector): F[Option[ByteVector]] = {
+      type Params = (Node, ByteVector)
+      def loop(params: Params): F[Either[Params, Option[ByteVector]]] =
+        params match {
+          case (_, ByteVector.empty) => Sync[F].pure(none.asRight) //Not found
+          case (curNode, prefix) =>
+            curNode(byteToInt(prefix.head)) match {
+              case EmptyItem => Sync[F].pure(none.asRight) //Not found
+
+              case Leaf(leafPrefix, value) =>
+                if (leafPrefix == prefix.tail) Sync[F].pure(value.some.asRight) //Happy end
+                else Sync[F].pure(none.asRight)                                 //Not found
+
+              case NodePtr(ptrPrefix, ptr) =>
+                val (_, prefixRest, ptrPrefixRest) = commonPrefix(prefix.tail, ptrPrefix)
+                if (ptrPrefixRest.isEmpty) loadNode(ptr).map(n => (n, prefixRest).asLeft) //Deeper
+                else Sync[F].pure(none.asRight)                                           //Not found
+            }
+        }
+      Sync[F].tailRecM(startNode, startPrefix)(loop)
+    }
+
+    /**
+      * Create node from [[Item]].
+      * If item is NodePtr and prefix is empty - load child node
+      */
+    private def createNodeFromItem(item: Item): F[Node] =
+      item match {
+        case EmptyItem => emptyNode.pure
+        case Leaf(leafPrefix, leafValue) =>
+          assert(
+            leafPrefix.nonEmpty,
+            "Impossible to create a node. LeafPrefix should be non empty."
+          )
+          emptyNode.updated(byteToInt(leafPrefix.head), Leaf(leafPrefix.tail, leafValue)).pure
+        case NodePtr(nodePtrPrefix, ptr) =>
+          if (nodePtrPrefix.isEmpty) loadNode(ptr)
+          else
+            emptyNode.updated(byteToInt(nodePtrPrefix.head), NodePtr(nodePtrPrefix.tail, ptr)).pure
+      }
+
+    /**
+      * Optimize and save Node, create item from this Node
+      */
+    private def saveNodeAndCreateItem(
+        node: Node,
+        prefix: ByteVector,
+        compaction: Boolean = true
+    ): Item =
+      if (compaction) {
+        val nonEmptyItems = node.iterator.filter(_ != EmptyItem).take(2).toList
+        nonEmptyItems.size match {
+          case 0 => EmptyItem //all items are empty
+          case 1 => //only one item is not empty - merge child and parent nodes
+            val idxItem = node.indexOf(nonEmptyItems.head)
+            nonEmptyItems.head match {
+              case EmptyItem => EmptyItem
+              case Leaf(leafPrefix, value) =>
+                Leaf(prefix ++ ByteVector(idxItem) ++ leafPrefix, value)
+              case NodePtr(nodePtrPrefix, ptr) =>
+                NodePtr(prefix ++ ByteVector(idxItem) ++ nodePtrPrefix, ptr)
+            }
+          case 2 => //2 or more items are not empty
+            NodePtr(prefix, saveNode(node))
+        }
+      } else NodePtr(prefix, saveNode(node))
+
+    /**
+      * Save new leaf value to this part of tree (start from curItems).
+      * Rehash and save all depend node to cacheW. Return updated curItems.
+      * If exist leaf with same prefix but different value - update leaf value.
+      * If exist leaf with same prefix and same value - return [[None]].
+      */
+    def update(
+        curItem: Item,
+        insPrefix: ByteVector,
+        insValue: ByteVector
+    ): F[Option[Item]] =
+      curItem match {
+        case EmptyItem =>
+          (Leaf(insPrefix, insValue): Item).some.pure //update EmptyItem to Leaf
+
+        case Leaf(leafPrefix, leafValue) =>
+          assert(leafPrefix.size == insPrefix.size, "All Radix keys should be same length")
+          if (leafPrefix == insPrefix) {
+            if (insValue == leafValue) none[Item].pure
+            else (Leaf(insPrefix, insValue): Item).some.pure
+          } //update Leaf
+          else {
+            // Create child node, insert existing and new leaf in this node
+            // intentionally not recursive for speed up
+            val (commPrefix, insPrefixRest, leafPrefixRest) = commonPrefix(insPrefix, leafPrefix)
+            val newNode = emptyNode
+              .updated(byteToInt(leafPrefixRest.head), Leaf(leafPrefixRest.tail, leafValue))
+              .updated(byteToInt(insPrefixRest.head), Leaf(insPrefixRest.tail, insValue))
+            saveNodeAndCreateItem(newNode, commPrefix, compaction = false).some.pure
+          }
+
+        case NodePtr(ptrPrefix, ptr) =>
+          assert(ptrPrefix.size < insPrefix.size, "Radix key should be longer than NodePtr key")
+          val (commPrefix, insPrefixRest, ptrPrefixRest) = commonPrefix(insPrefix, ptrPrefix)
+          if (ptrPrefixRest.isEmpty) {
+            val (childItemIdx, childInsPrefix) =
+              (byteToInt(insPrefixRest.head), insPrefixRest.tail)
+            //add new node to existing child node
+            for {
+              childNode    <- loadNode(ptr)
+              childItemOpt <- update(childNode(childItemIdx), childInsPrefix, insValue) //deeper
+              returnedItem = childItemOpt.map { childItem =>
+                val updatedChildNode = childNode.updated(childItemIdx, childItem)
+                saveNodeAndCreateItem(updatedChildNode, commPrefix, compaction = false)
+              }
+            } yield returnedItem
+          } else {
+            // Create child node, insert existing Ptr and new leaf in this node
+            val newNode = emptyNode
+              .updated(byteToInt(ptrPrefixRest.head), NodePtr(ptrPrefixRest.tail, ptr))
+              .updated(byteToInt(insPrefixRest.head), Leaf(insPrefixRest.tail, insValue))
+            saveNodeAndCreateItem(newNode, commPrefix, compaction = false).some.pure
+          }
+      }
+
+    /**
+      * Delete leaf value from this part of tree (start from curItem).
+      * Rehash and save all depend node to cacheW. Return updated curItem.
+      * If not found leaf with  delPrefix - return [[None]].
+      */
+    def delete(curItem: Item, delPrefix: ByteVector): F[Option[Item]] =
+      curItem match {
+        case EmptyItem => none[Item].pure //Not found
+
+        case Leaf(leafPrefix, _) =>
+          if (leafPrefix == delPrefix) (EmptyItem: Item).some.pure //Happy end
+          else none[Item].pure                                     //Not found
+
+        case NodePtr(ptrPrefix, ptr) =>
+          val (commPrefix, delPrefixRest, ptrPrefixRest) = commonPrefix(delPrefix, ptrPrefix)
+          if (ptrPrefixRest.nonEmpty || delPrefixRest.isEmpty) none[Item].pure //Not found
+          else {
+            val (childItemIdx, childDelPrefix) =
+              (byteToInt(delPrefixRest.head), delPrefixRest.tail)
+            for {
+              childNode    <- loadNode(ptr)
+              childItemOpt <- delete(childNode(childItemIdx), childDelPrefix) //deeper
+              returnedChild = childItemOpt.map { childItem =>
+                saveNodeAndCreateItem(childNode.updated(childItemIdx, childItem), commPrefix)
+              }
+            } yield returnedChild
+          }
+      }
+
+    /**
+      * Parallel processing of HistoryActions in this part of tree (start from curNode).
+      * New data load to [[cacheW]].
+      * Return updated curNode. if no action was taken - return [[None]].
+      */
+    def makeActions(curNode: Node, curActions: List[HistoryAction]): F[Option[Node]] = {
+      val groups = curActions
+        .groupBy( //fixme
+          _.key.headOption.getOrElse({
+            assert(assertion = false, "The length of all prefixes in the subtree must be the same")
+            0x00.toByte
+          })
+        )
+        .toList
+      val newGroupItemsF = groups.map {
+        case (groupIdx, groupActions) =>
+          val index = byteToInt(groupIdx)
+          val item  = curNode(index)
+          if (groupActions.length == 1) {
+            val newItem = groupActions.head match {
+              case InsertAction(key, hash) =>
+                update(item, ByteVector(key).tail, hash.bytes)
+              case DeleteAction(key) => delete(item, ByteVector(key).tail)
+            }
+            newItem.map((index, _))
+          } else {
+            val notExistInsertAction = groupActions.collectFirst { case _: InsertAction => true }.isEmpty
+            val clearGroupActions =
+              if (item == EmptyItem && notExistInsertAction) groupActions.collect {
+                case v: InsertAction => v
+              } else groupActions
+            if (clearGroupActions.isEmpty) (index, none[Item]).pure
+            else {
+              val newActions = clearGroupActions.map {
+                case InsertAction(key, hash) => InsertAction(key.tail, hash)
+                case DeleteAction(key)       => DeleteAction(key.tail)
+              }
+              for {
+                createdNode <- createNodeFromItem(curNode(index))
+                newNodeOpt  <- makeActions(createdNode, newActions)
+                newItem     = newNodeOpt.map(saveNodeAndCreateItem(_, ByteVector.empty))
+              } yield (index, newItem)
+            }
+          }
+      }
+      for {
+        newGroupItems <- newGroupItemsF.parSequence
+        newCurNode = newGroupItems.foldLeft(curNode) {
+          case (tempNode, (index, newItemOpt)) =>
+            newItemOpt.map(tempNode.updated(index, _)).getOrElse(tempNode)
+        }
+      } yield if (newCurNode != curNode) newCurNode.some else none
+    }
+
+    /**
+      * Pretty print radix tree
+      */
+    final def print(curNode: Node, indentLevel: Int = 0): Unit = {
+      val indent               = Seq.fill(indentLevel * 2)(" ").mkString
+      def prn(s: String): Unit = println(s"$indent$s")
+      curNode.zipWithIndex foreach {
+        case (EmptyItem, _) => Unit
+
+        case (Leaf(leafPrefix, value), idx) =>
+          prn(s"${idx.toHexString.toUpperCase}${leafPrefix.toHex}: ${value.toHex}")
+
+        case (NodePtr(ptrPrefix, ptr), idx) =>
+          prn(s"${idx.toHexString.toUpperCase}${ptrPrefix.toHex} [${ptr.toHex}]")
+          loadNode(ptr).map(print(_, indentLevel + 1))
+      }
+    }
+  }
+}

--- a/rspace/src/main/scala/coop/rchain/rspace/history/instances/RadixHistoryWithExternReadCache.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/history/instances/RadixHistoryWithExternReadCache.scala
@@ -22,7 +22,7 @@ object RadixHistoryWithExternReadCache {
    * Where hash  - Blake2b256Hash of serializing nodes data,
    *       node - deserialized data of this node.
    */
-  val maxCacheRecordCount = 1000000
+  private val maxCacheRecordCount = 1000000
   val cache: LimitTrieMapCache[ByteVector, Node] =
     new LimitTrieMapCache[ByteVector, Node](maxCacheRecordCount)
 

--- a/rspace/src/main/scala/coop/rchain/rspace/history/instances/RadixHistoryWithExternReadCache.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/history/instances/RadixHistoryWithExternReadCache.scala
@@ -22,7 +22,7 @@ object RadixHistoryWithExternReadCache {
    * Where hash  - Blake2b256Hash of serializing nodes data,
    *       node - deserialized data of this node.
    */
-  val maxCacheRecordCount = 50
+  val maxCacheRecordCount = 1000000
   val cache: LimitTrieMapCache[ByteVector, Node] =
     new LimitTrieMapCache[ByteVector, Node](maxCacheRecordCount)
 

--- a/rspace/src/main/scala/coop/rchain/rspace/history/instances/RadixHistoryWithExternReadCache.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/history/instances/RadixHistoryWithExternReadCache.scala
@@ -4,8 +4,7 @@ import cats.Parallel
 import cats.effect.Sync
 import cats.syntax.all._
 import coop.rchain.rspace.hashing.Blake2b256Hash
-import coop.rchain.rspace.history.RadixTreeWithExternReadCache._
-import coop.rchain.rspace.history.LimitTrieMapCache
+import coop.rchain.rspace.history.RadixTree._
 import coop.rchain.rspace.history._
 import coop.rchain.shared.syntax.sharedSyntaxKeyValueStore
 import coop.rchain.store.{KeyValueStore, KeyValueTypedStore}
@@ -15,23 +14,24 @@ import scodec.bits.ByteVector
   * History implementation with radix tree
   */
 object RadixHistoryWithExternReadCache {
-  val emptyRootHash: Blake2b256Hash = Blake2b256Hash.fromByteArray(hashNode(emptyNode)._1.toArray)
+  val emptyRootHash: Blake2b256Hash = Blake2b256Hash.fromByteVector(hashNode(emptyNode)._1)
 
   /**
-    * Cache for storing read and decoded nodes.
-    * In cache load kv-pair (hash, node).
-    * Where hash  - Blake2b256Hash of serializing nodes data,
-    *       node - deserialized data of this node.
-    */
+   * Cache for storing read and decoded nodes.
+   * In cache load kv-pair (hash, node).
+   * Where hash  - Blake2b256Hash of serializing nodes data,
+   *       node - deserialized data of this node.
+   */
   val maxCacheRecordCount = 50
   val cache: LimitTrieMapCache[ByteVector, Node] =
     new LimitTrieMapCache[ByteVector, Node](maxCacheRecordCount)
+
   def apply[F[_]: Sync: Parallel](
       root: Blake2b256Hash,
       store: KeyValueTypedStore[F, ByteVector, ByteVector]
   ): F[RadixHistoryWithExternReadCache[F]] =
     for {
-      impl <- Sync[F].delay(new RadixTreeImpl[F](store, cache))
+      impl <- Sync[F].delay(new RadixTreeImpl[F](store))
       node <- impl.loadNode(root.bytes, noAssert = true)
     } yield RadixHistoryWithExternReadCache(root, node, impl, store, cache)
 
@@ -54,7 +54,7 @@ final case class RadixHistoryWithExternReadCache[F[_]: Sync: Parallel](
 
   override def reset(root: Blake2b256Hash): F[History[F]] =
     for {
-      impl <- Sync[F].delay(new RadixTreeImpl[F](store, cache))
+      impl <- Sync[F].delay(new RadixTreeImpl[F](store))
       node <- impl.loadNode(root.bytes, noAssert = true)
     } yield this.copy(root, node, impl, store)
 
@@ -63,7 +63,8 @@ final case class RadixHistoryWithExternReadCache[F[_]: Sync: Parallel](
 
   override def process(actions: List[HistoryAction]): F[History[F]] =
     for {
-      _ <- new RuntimeException("Cannot process duplicate actions on one key").raiseError
+      // TODO: To improve time perfomance, it is possible to implement this check into the makeActions().
+      _ <- new RuntimeException("Cannot process duplicate actions on one key.").raiseError
             .unlessA(hasNoDuplicates(actions))
 
       newRootNodeOpt <- impl.makeActions(rootNode, actions)
@@ -75,7 +76,7 @@ final case class RadixHistoryWithExternReadCache[F[_]: Sync: Parallel](
     } yield
       if (newRootHash.isDefined)
         this.copy(
-          Blake2b256Hash.fromByteArray(newRootHash.get.toArray),
+          Blake2b256Hash.fromByteVector(newRootHash.get),
           newRootNodeOpt.get,
           impl,
           store
@@ -83,5 +84,5 @@ final case class RadixHistoryWithExternReadCache[F[_]: Sync: Parallel](
       else this
 
   private def hasNoDuplicates(actions: List[HistoryAction]) =
-    actions.map(_.key).toSet.size == actions.size
+    actions.map(_.key).distinct.size == actions.size
 }

--- a/rspace/src/main/scala/coop/rchain/rspace/history/instances/RadixHistoryWithExternReadCache.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/history/instances/RadixHistoryWithExternReadCache.scala
@@ -4,7 +4,7 @@ import cats.Parallel
 import cats.effect.Sync
 import cats.syntax.all._
 import coop.rchain.rspace.hashing.Blake2b256Hash
-import coop.rchain.rspace.history.RadixTree._
+import coop.rchain.rspace.history.RadixTreeWithExternReadCache._
 import coop.rchain.rspace.history._
 import coop.rchain.shared.syntax.sharedSyntaxKeyValueStore
 import coop.rchain.store.{KeyValueStore, KeyValueTypedStore}
@@ -31,7 +31,7 @@ object RadixHistoryWithExternReadCache {
       store: KeyValueTypedStore[F, ByteVector, ByteVector]
   ): F[RadixHistoryWithExternReadCache[F]] =
     for {
-      impl <- Sync[F].delay(new RadixTreeImpl[F](store))
+      impl <- Sync[F].delay(new RadixTreeImpl[F](store, cache))
       node <- impl.loadNode(root.bytes, noAssert = true)
     } yield RadixHistoryWithExternReadCache(root, node, impl, store, cache)
 
@@ -54,7 +54,7 @@ final case class RadixHistoryWithExternReadCache[F[_]: Sync: Parallel](
 
   override def reset(root: Blake2b256Hash): F[History[F]] =
     for {
-      impl <- Sync[F].delay(new RadixTreeImpl[F](store))
+      impl <- Sync[F].delay(new RadixTreeImpl[F](store, cache))
       node <- impl.loadNode(root.bytes, noAssert = true)
     } yield this.copy(root, node, impl, store)
 

--- a/rspace/src/main/scala/coop/rchain/rspace/history/instances/RadixHistoryWithExternReadCache.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/history/instances/RadixHistoryWithExternReadCache.scala
@@ -1,0 +1,87 @@
+package coop.rchain.rspace.history.instances
+
+import cats.Parallel
+import cats.effect.Sync
+import cats.syntax.all._
+import coop.rchain.rspace.hashing.Blake2b256Hash
+import coop.rchain.rspace.history.RadixTreeWithExternReadCache._
+import coop.rchain.rspace.history.LimitTrieMapCache
+import coop.rchain.rspace.history._
+import coop.rchain.shared.syntax.sharedSyntaxKeyValueStore
+import coop.rchain.store.{KeyValueStore, KeyValueTypedStore}
+import scodec.bits.ByteVector
+
+/**
+  * History implementation with radix tree
+  */
+object RadixHistoryWithExternReadCache {
+  val emptyRootHash: Blake2b256Hash = Blake2b256Hash.fromByteArray(hashNode(emptyNode)._1.toArray)
+
+  /**
+    * Cache for storing read and decoded nodes.
+    * In cache load kv-pair (hash, node).
+    * Where hash  - Blake2b256Hash of serializing nodes data,
+    *       node - deserialized data of this node.
+    */
+  val maxCacheRecordCount = 50
+  val cache: LimitTrieMapCache[ByteVector, Node] =
+    new LimitTrieMapCache[ByteVector, Node](maxCacheRecordCount)
+  def apply[F[_]: Sync: Parallel](
+      root: Blake2b256Hash,
+      store: KeyValueTypedStore[F, ByteVector, ByteVector]
+  ): F[RadixHistoryWithExternReadCache[F]] =
+    for {
+      impl <- Sync[F].delay(new RadixTreeImpl[F](store, cache))
+      node <- impl.loadNode(root.bytes, noAssert = true)
+    } yield RadixHistoryWithExternReadCache(root, node, impl, store, cache)
+
+  def createStore[F[_]: Sync](
+      store: KeyValueStore[F]
+  ): KeyValueTypedStore[F, ByteVector, ByteVector] =
+    store.toTypedStore(scodec.codecs.bytes, scodec.codecs.bytes)
+}
+
+final case class RadixHistoryWithExternReadCache[F[_]: Sync: Parallel](
+    rootHash: Blake2b256Hash,
+    rootNode: Node,
+    impl: RadixTreeImpl[F],
+    store: KeyValueTypedStore[F, ByteVector, ByteVector],
+    cache: LimitTrieMapCache[ByteVector, Node]
+) extends History[F] {
+  override type HistoryF = History[F]
+
+  override def root: Blake2b256Hash = rootHash
+
+  override def reset(root: Blake2b256Hash): F[History[F]] =
+    for {
+      impl <- Sync[F].delay(new RadixTreeImpl[F](store, cache))
+      node <- impl.loadNode(root.bytes, noAssert = true)
+    } yield this.copy(root, node, impl, store)
+
+  override def read(key: ByteVector): F[Option[ByteVector]] =
+    impl.read(rootNode, key)
+
+  override def process(actions: List[HistoryAction]): F[History[F]] =
+    for {
+      _ <- new RuntimeException("Cannot process duplicate actions on one key").raiseError
+            .unlessA(hasNoDuplicates(actions))
+
+      newRootNodeOpt <- impl.makeActions(rootNode, actions)
+      newRootHash <- newRootNodeOpt.traverse { newRootNode =>
+                      val hash = impl.saveNode(newRootNode)
+                      impl.commit().as(hash)
+                    }
+      _ <- Sync[F].delay(impl.clearWriteCache())
+    } yield
+      if (newRootHash.isDefined)
+        this.copy(
+          Blake2b256Hash.fromByteArray(newRootHash.get.toArray),
+          newRootNodeOpt.get,
+          impl,
+          store
+        )
+      else this
+
+  private def hasNoDuplicates(actions: List[HistoryAction]) =
+    actions.map(_.key).toSet.size == actions.size
+}


### PR DESCRIPTION
## Overview
I'm just want to show current stage
 of my task:
 https://github.com/rchain/rchain/issues/3581

### Notes
Current version of cache is too slow to use it:
https://github.com/SivkovAV/rchain/blob/radix-history-with-single-cache/rspace/src/main/scala/coop/rchain/rspace/history/LimitTrieMapCache.scala

There is an idea: use just map (without queue): TrieMap[key, (Tuple[value, nextKey, prevKey]] - we combine map and queue.
Other words, we integrate information about queue in map.
But I need two vars to store top key and bottom key for fast working.
 As I undestood, using var on source code - this is very very bad. So I prepare functional implementation. But now I have another problem: RadixTree using cache like no functional (it calls mutable methods: https://github.com/SivkovAV/rchain/blob/radix-history-with-single-cache/rspace/src/main/scala/coop/rchain/rspace/history/RadixTree.scala#L540).
May be somebody have better practic in same tasks?
My functional implementation of cache:
https://github.com/SivkovAV/rchain/blob/radix-history-with-single-cache/rspace/src/main/scala/coop/rchain/rspace/history/FastLimitTrieMapCache.scala
Another (not functional friendly) variant. It's not tested yet:
https://github.com/SivkovAV/rchain/blob/radix-history-with-single-cache/rspace/src/main/scala/coop/rchain/rspace/history/FastLimitTrieMapCacheFunc.scala

### I'm not sure :) that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).