### PR TITLE
New rho types example

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -66,6 +66,13 @@ lazy val projectSettings = Seq(
   scalafmtOnCompile := !sys.env.contains("CI"), // disable in CI environments
   ThisBuild / scapegoatVersion := "2.1.1",
   ThisBuild / scalacOptions += "semanticdb:synthetics:on",
+  ThisBuild / scalacOptions ++= Seq(
+    "-language:higherKinds",
+    "-language:implicitConversions",
+    "-language:postfixOps",
+    "-language:experimental.macros",
+    "-language:reflectiveCalls"
+  ),
   Test / testOptions += Tests.Argument("-oD"), //output test durations
   javacOptions ++= Seq("-source", "11", "-target", "11"),
   Test / fork := true,

--- a/models/src/main/scala/coop/rchain/models/rholangN/Par.scala
+++ b/models/src/main/scala/coop/rchain/models/rholangN/Par.scala
@@ -1,0 +1,104 @@
+package coop.rchain.models.rholangN
+
+import scodec.bits.ByteVector
+import coop.rchain.rspace.hashing.Blake2b256Hash
+
+import scala.collection.immutable.BitSet
+import ParManager.Constructor._
+import ParManager._
+
+sealed trait Par {
+  protected def meta: ParMetaData
+
+  override def equals(x: Any): Boolean = ParManager.equals(this, x)
+  override def hashCode: Int           = meta.rhoHash.hashCode()
+
+  def serializedSize: Int         = meta.serializedSize
+  def rhoHash: Blake2b256Hash     = meta.rhoHash
+  def locallyFree: BitSet         = meta.locallyFree
+  def connectiveUsed: Boolean     = meta.connectiveUsed
+  def evalRequired: Boolean       = meta.evalRequired
+  def substituteRequired: Boolean = meta.substituteRequired
+
+  def toBytes: ByteVector = parToBytes(this)
+}
+object Par {
+  def fromBytes(bytes: ByteVector): Par = parFromBytes(bytes)
+}
+sealed trait Expr extends Par
+
+class ParProc(val ps: SortedParSeq, protected val meta: ParMetaData) extends Par {
+  def add(p: Par): ParProc = ParProc(ps.add(p))
+}
+object ParProc {
+  def apply(ps: Seq[Par]): ParProc           = createParProc(ps)
+  def apply(sortedPs: SortedParSeq): ParProc = createParProc(sortedPs)
+}
+
+final class GNil(protected val meta: ParMetaData) extends Par
+object GNil { def apply(): GNil = createGNil }
+
+final class GInt(val v: Long, protected val meta: ParMetaData) extends Expr
+object GInt { def apply(v: Long): GInt = createGInt(v) }
+
+final class EList(val ps: Seq[Par], protected val meta: ParMetaData) extends Expr
+object EList {
+  def apply(): EList             = createEList(Seq())
+  def apply(p: Par): EList       = createEList(Seq(p))
+  def apply(ps: Seq[Par]): EList = createEList(ps)
+}
+
+final class Send(
+    val chan: Par,
+    val data: SortedParSeq,
+    val persistent: Boolean,
+    protected val meta: ParMetaData
+) extends Par
+object Send {
+  def apply(chan: Par, data: Seq[Par], persistent: Boolean): Send =
+    createSend(chan, data, persistent)
+}
+
+final class ParMetaData(
+    val serializedSize: Int,
+    val rhoHash: Blake2b256Hash,
+    val locallyFree: BitSet,
+    val connectiveUsed: Boolean,
+    val evalRequired: Boolean,
+    val substituteRequired: Boolean
+)
+
+class SortedParSeq(private val sortedData: Seq[Par]) {
+  def add(element: Par): SortedParSeq = {
+    val index = sortedData.indexWhere(_.rhoHash.bytes >= element.rhoHash.bytes)
+    if (index == -1) {
+      new SortedParSeq(sortedData :+ element)
+    } else {
+      new SortedParSeq(sortedData.patch(index, Seq(element), 0))
+    }
+  }
+  def merge(other: SortedParSeq): SortedParSeq =
+    new SortedParSeq(
+      (sortedData ++ other.sortedData).sorted(Ordering.by((p: Par) => p.rhoHash.bytes))
+    )
+  def remove(element: Par): SortedParSeq = {
+    val index = sortedData.indexWhere(_.rhoHash.bytes == element.rhoHash.bytes)
+    if (index != -1) {
+      new SortedParSeq(sortedData.patch(index, Nil, 1))
+    } else {
+      this
+    }
+  }
+  def foreach(f: Par => Unit): Unit = sortedData.foreach(f)
+  def size: Int                     = sortedData.size
+  def toSeq: Seq[Par]               = sortedData
+}
+
+object SortedParSeq {
+  // From presorted Seq[Par]
+  def fromSorted(SortedParSeq: Seq[Par]): SortedParSeq =
+    new SortedParSeq(SortedParSeq)
+  // From unsorted Seq[Par]
+  def apply(elements: Seq[Par]): SortedParSeq =
+    new SortedParSeq(elements.sorted(Ordering.by((p: Par) => p.rhoHash.bytes)))
+}

--- a/models/src/main/scala/coop/rchain/models/rholangN/ParManager.scala
+++ b/models/src/main/scala/coop/rchain/models/rholangN/ParManager.scala
@@ -1,0 +1,411 @@
+package coop.rchain.models.rholangN
+
+import cats.effect.Sync
+import com.google.protobuf.{CodedInputStream, CodedOutputStream}
+import coop.rchain.rspace.hashing.Blake2b256Hash
+import scodec.bits.ByteVector
+
+import java.io.{ByteArrayInputStream, ByteArrayOutputStream, InputStream, OutputStream}
+import java.lang.Math.floorDiv
+import scala.collection.immutable.BitSet
+import coop.rchain.catscontrib.effect.implicits.sEval
+import cats.implicits._
+
+object ParManager {
+  type M[T] = cats.Eval[T]
+
+  def parToBytes(p: Par): ByteVector = {
+    val baos = new ByteArrayOutputStream(p.serializedSize)
+    Codecs.serialize[M](p, baos).value
+    ByteVector(baos.toByteArray)
+  }
+
+  def parFromBytes(bv: ByteVector): Par = {
+    val bais = new ByteArrayInputStream(bv.toArray)
+    Codecs.deserialize[M](bais).value
+  }
+
+  def equals(self: Par, other: Any): Boolean = other match {
+    case x: Par => x.rhoHash == self.rhoHash
+    case _      => false
+  }
+
+  object Constructor {
+    import SerializedSize._
+    import RhoHash._
+    import LocallyFree._
+    import ConnectiveUsed._
+    import EvalRequired._
+    import SubstituteRequired._
+
+    def createParProc(ps: Seq[Par]): ParProc = createParProc(SortedParSeq(ps))
+
+    def createParProc(sortedPs: SortedParSeq): ParProc = {
+      val size = sizeParProc(sortedPs)
+      val hash = hashParProc(sortedPs)
+      val lf   = locallyFreeParProc(sortedPs)
+      val cu   = connectiveUsedParProc(sortedPs)
+      val er   = evalRequiredParProc(sortedPs)
+      val sr   = substituteRequiredParProc(sortedPs)
+      val meta = new ParMetaData(size, hash, lf, cu, er, sr)
+      new ParProc(sortedPs, meta)
+    }
+
+    def createGNil: GNil = {
+      val size = sizeGNil()
+      val hash = hashGNil()
+      val lf   = locallyFreeGNil()
+      val cu   = connectiveUsedGNil()
+      val er   = evalRequiredGNil()
+      val sr   = substituteRequiredGNil()
+      val meta = new ParMetaData(size, hash, lf, cu, er, sr)
+      new GNil(meta)
+    }
+
+    def createGInt(v: Long): GInt = {
+      val size = sizeGInt(v)
+      val hash = hashGInt(v)
+      val lf   = locallyFreeGInt(v)
+      val cu   = connectiveUsedGInt(v)
+      val er   = evalRequiredGInt(v)
+      val sr   = substituteRequiredGInt(v)
+      val meta = new ParMetaData(size, hash, lf, cu, er, sr)
+      new GInt(v, meta)
+    }
+
+    def createEList(ps: Seq[Par]): EList = {
+      val size = sizeEList(ps)
+      val hash = hashEList(ps)
+      val lf   = locallyFreeEList(ps)
+      val cu   = connectiveUsedEList(ps)
+      val er   = evalRequiredEList(ps)
+      val sr   = substituteRequiredEList(ps)
+      val meta = new ParMetaData(size, hash, lf, cu, er, sr)
+      new EList(ps, meta)
+    }
+
+    def createSend(chan: Par, data: Seq[Par], persistent: Boolean): Send = {
+      val sortedData = SortedParSeq(data)
+      val size       = sizeSend(chan, sortedData, persistent)
+      val hash       = hashSend(chan, sortedData, persistent)
+      val lf         = locallyFreeSend(chan, sortedData, persistent)
+      val cu         = connectiveUsedSend(chan, sortedData, persistent)
+      val er         = evalRequiredSend(chan, sortedData, persistent)
+      val sr         = substituteRequiredSend(chan, sortedData, persistent)
+      val meta       = new ParMetaData(size, hash, lf, cu, er, sr)
+      new Send(chan, sortedData, persistent, meta)
+    }
+  }
+
+  private object Constants {
+    final val longSize    = 8
+    final val booleanSize = 1
+    final val hashSize    = Blake2b256Hash.length
+
+    final val tagSize       = 1
+    final val PARPROC: Byte = 0x01.toByte
+    final val GNIL: Byte    = 0x02.toByte
+    final val GINT: Byte    = 0x04.toByte
+    final val ELIST: Byte   = 0x08.toByte
+    final val SEND: Byte    = 0x80.toByte
+  }
+
+  private object RhoHash {
+    import Constants._
+    import java.util.concurrent.atomic.AtomicInteger
+
+    private class Hashable(val tag: Byte, val bodySize: Int) {
+
+      private val arrSize: Int     = bodySize + tagSize
+      private val arr: Array[Byte] = new Array[Byte](arrSize)
+      private val pos              = new AtomicInteger(tagSize)
+
+      arr(0) = tag // Fill the first element of arr with the tag
+
+      def appendByte(b: Byte): Unit = {
+        val currentPos = pos.getAndIncrement()
+        assert(currentPos + 1 <= arrSize, "Array size exceeded")
+        arr(currentPos) = b
+      }
+
+      def appendBytes(bytes: Array[Byte]): Unit = {
+        val bytesLength = bytes.length
+        val currentPos  = pos.getAndAdd(bytesLength)
+        assert(currentPos + bytesLength <= arrSize, "Array size exceeded")
+        Array.copy(bytes, 0, arr, currentPos, bytesLength)
+      }
+
+      def appendParHash(p: Par): Unit = appendBytes(p.rhoHash.bytes.toArray)
+
+      // Get the hash of the current array
+      def calcHash: Blake2b256Hash = {
+        val curSize = pos.get()
+
+        if (curSize <= hashSize) {
+          if (curSize == hashSize) {
+            Blake2b256Hash.fromByteArray(arr)
+          } else {
+            val newBytes     = new Array[Byte](hashSize)
+            val dataStartPos = hashSize - curSize
+
+            for (i <- 0 until hashSize) {
+              if (i < dataStartPos) newBytes(i) = 0x00.toByte // fill empty place with 0x00.toByte
+              else newBytes(i) = arr(i - dataStartPos)
+            }
+            Blake2b256Hash.fromByteArray(newBytes)
+          }
+        } else {
+          val hashData = arr.slice(0, curSize)
+          Blake2b256Hash.create(hashData)
+        }
+      }
+    }
+
+    private object Hashable {
+      def apply(tag: Byte, size: Int): Hashable = new Hashable(tag, size)
+    }
+
+    def hashParProc(ps: SortedParSeq): Blake2b256Hash = {
+      val bodySize = hashSize * ps.size
+      val hashable = Hashable(PARPROC, bodySize)
+      ps.foreach(hashable.appendParHash)
+      hashable.calcHash
+    }
+
+    def hashGNil(): Blake2b256Hash = Hashable(GNIL, 0).calcHash
+
+    def hashGInt(v: Long): Blake2b256Hash = {
+      def longToBytes(value: Long): Array[Byte] = {
+        val byteArray = new Array[Byte](longSize)
+        for (i <- 0 until longSize) {
+          byteArray(7 - i) = ((value >>> (i * longSize)) & 0xFF).toByte
+        }
+        byteArray
+      }
+      val hashable = Hashable(GINT, longSize)
+      hashable.appendBytes(longToBytes(v))
+      hashable.calcHash
+    }
+
+    def hashEList(ps: Seq[Par]): Blake2b256Hash = {
+      val bodySize = hashSize * ps.size
+      val hashable = Hashable(ELIST, bodySize)
+      ps.foreach(hashable.appendParHash)
+      hashable.calcHash
+    }
+
+    def hashSend(chan: Par, data: SortedParSeq, persistent: Boolean): Blake2b256Hash = {
+      def booleanToByte(v: Boolean): Byte = if (v) 1 else 0
+
+      val bodySize = hashSize * (data.size + 1) + booleanSize
+      val hashable = Hashable(SEND, bodySize)
+      hashable.appendParHash(chan)
+      data.foreach(hashable.appendParHash)
+      hashable.appendByte(booleanToByte(persistent))
+      hashable.calcHash
+    }
+  }
+
+  private object SerializedSize {
+    import Constants._
+
+    private def sizeTag(): Int              = tagSize
+    private def sizeLength(value: Int): Int = CodedOutputStream.computeUInt32SizeNoTag(value)
+    private def sizeLong(value: Long): Int  = CodedOutputStream.computeInt64SizeNoTag(value)
+    private def sizeBool(): Int             = 1
+    private def sizePar(p: Par): Int        = p.serializedSize
+    private def sizePars(ps: Seq[Par]): Int = ps.map(sizePar).sum
+
+    def sizeParProc(ps: SortedParSeq): Int = {
+      val tagSize    = sizeTag()
+      val lengthSize = sizeLength(ps.size)
+      val psSize     = sizePars(ps.toSeq)
+      tagSize + lengthSize + psSize
+    }
+
+    def sizeGNil(): Int = sizeTag()
+
+    def sizeGInt(v: Long): Int = sizeTag() + sizeLong(v)
+
+    def sizeEList(ps: Seq[Par]): Int = {
+      val tagSize    = sizeTag()
+      val lengthSize = sizeLength(ps.size)
+      val psSize     = sizePars(ps)
+      tagSize + lengthSize + psSize
+    }
+
+    def sizeSend(chan: Par, data: SortedParSeq, persistent: Boolean): Int = {
+      val tagSize        = sizeTag()
+      val chanSize       = sizePar(chan)
+      val dataLengthSize = sizeLength(data.size)
+      val dataSize       = sizePars(data.toSeq)
+      val persistentSize = sizeBool()
+      tagSize + chanSize + dataLengthSize + dataSize + persistentSize
+    }
+  }
+
+  private object LocallyFree {
+    private def locallyFreeParSeq(ps: Seq[Par]) =
+      ps.foldLeft(BitSet())((acc, p) => acc | p.locallyFree)
+
+    def locallyFreeParProc(ps: SortedParSeq): BitSet = locallyFreeParSeq(ps.toSeq)
+
+    def locallyFreeGNil(): BitSet = BitSet()
+
+    def locallyFreeGInt(v: Long): BitSet = BitSet()
+
+    def locallyFreeEList(ps: Seq[Par]): BitSet = locallyFreeParSeq(ps)
+
+    def locallyFreeSend(chan: Par, data: SortedParSeq, persistent: Boolean): BitSet =
+      chan.locallyFree | locallyFreeParSeq(data.toSeq)
+  }
+
+  private object ConnectiveUsed {
+    private def cUsedParSeq(ps: Seq[Par]) =
+      ps.exists(_.connectiveUsed)
+
+    def connectiveUsedParProc(ps: SortedParSeq): Boolean = cUsedParSeq(ps.toSeq)
+
+    def connectiveUsedGNil(): Boolean = false
+
+    def connectiveUsedGInt(v: Long): Boolean = false
+
+    def connectiveUsedEList(ps: Seq[Par]): Boolean = cUsedParSeq(ps)
+
+    def connectiveUsedSend(chan: Par, data: SortedParSeq, persistent: Boolean): Boolean =
+      chan.connectiveUsed || cUsedParSeq(data.toSeq)
+  }
+
+  private object EvalRequired {
+    private def eRequiredParSeq(ps: Seq[Par]) =
+      ps.exists(_.evalRequired)
+
+    def evalRequiredParProc(ps: SortedParSeq): Boolean = eRequiredParSeq(ps.toSeq)
+
+    def evalRequiredGNil(): Boolean = false
+
+    def evalRequiredGInt(v: Long): Boolean = false
+
+    def evalRequiredEList(ps: Seq[Par]): Boolean = eRequiredParSeq(ps)
+
+    def evalRequiredSend(chan: Par, data: SortedParSeq, persistent: Boolean): Boolean =
+      eRequiredParSeq(data.toSeq)
+  }
+
+  private object SubstituteRequired {
+    private def sRequiredParSeq(ps: Seq[Par]) =
+      ps.exists(_.substituteRequired)
+
+    def substituteRequiredParProc(ps: SortedParSeq): Boolean = sRequiredParSeq(ps.toSeq)
+
+    def substituteRequiredGNil(): Boolean = false
+
+    def substituteRequiredGInt(v: Long): Boolean = false
+
+    def substituteRequiredEList(ps: Seq[Par]): Boolean = sRequiredParSeq(ps)
+
+    def substituteRequiredSend(chan: Par, data: SortedParSeq, persistent: Boolean): Boolean =
+      sRequiredParSeq(data.toSeq)
+  }
+
+  private object Codecs {
+    import Constants._
+
+    def serialize[F[_]: Sync](par: Par, output: OutputStream): F[Unit] = {
+      val cos = CodedOutputStream.newInstance(output)
+
+      def writeTag(x: Byte): F[Unit]       = Sync[F].delay(cos.writeRawByte(x))
+      def writeLength(x: Int): F[Unit]     = Sync[F].delay(cos.writeUInt32NoTag(x))
+      def writeLong(x: Long): F[Unit]      = Sync[F].delay(cos.writeInt64NoTag(x))
+      def writeBool(x: Boolean): F[Unit]   = Sync[F].delay(cos.writeBoolNoTag(x))
+      def writePar(p: Par): F[Unit]        = Sync[F].defer(loop(p))
+      def writePars(ps: Seq[Par]): F[Unit] = ps.traverse_(loop)
+
+      def loop(p: Par): F[Unit] =
+        p match {
+          case parProc: ParProc =>
+            for {
+              _ <- writeTag(PARPROC)
+              _ <- writeLength(parProc.ps.size)
+              _ <- writePars(parProc.ps.toSeq)
+            } yield ()
+
+          case _: GNil =>
+            writeTag(GNIL)
+
+          case gInt: GInt =>
+            for {
+              _ <- writeTag(GINT)
+              _ <- writeLong(gInt.v)
+            } yield ()
+
+          case eList: EList =>
+            for {
+              _ <- writeTag(ELIST)
+              _ <- writeLength(eList.ps.size)
+              _ <- writePars(eList.ps)
+            } yield ()
+
+          case send: Send =>
+            for {
+              _ <- writeTag(SEND)
+              _ <- writePar(send.chan)
+              _ <- writeLength(send.data.size)
+              _ <- writePars(send.data.toSeq)
+              _ <- writeBool(send.persistent)
+            } yield ()
+
+        }
+      writePar(par) *> Sync[F].delay(cos.flush())
+    }
+
+    def deserialize[F[_]: Sync](input: InputStream): F[Par] = {
+      val cis = CodedInputStream.newInstance(input)
+
+      def readTag(): F[Byte]                 = Sync[F].delay(cis.readRawByte())
+      def readLength(): F[Int]               = Sync[F].delay(cis.readUInt32())
+      def readLong(): F[Long]                = Sync[F].delay(cis.readInt64())
+      def readBool(): F[Boolean]             = Sync[F].delay(cis.readBool())
+      def readPar(): F[Par]                  = Sync[F].defer(loop())
+      def readPars(count: Int): F[List[Par]] = (1 to count).toList.traverse(_ => readPar())
+
+      def loop(): F[Par] =
+        for {
+          tag <- readTag()
+          par <- tag match {
+                  case PARPROC =>
+                    for {
+                      count <- readLength()
+                      ps    <- readPars(count)
+                    } yield ParProc(ps)
+
+                  case GNIL =>
+                    Sync[F].pure(GNil())
+
+                  case GINT =>
+                    readLong().map(GInt(_))
+
+                  case ELIST =>
+                    for {
+                      count <- readLength()
+                      ps    <- readPars(count)
+                    } yield EList(ps)
+
+                  case SEND =>
+                    for {
+                      chan       <- readPar()
+                      dataSize   <- readLength()
+                      dataSeq    <- readPars(dataSize)
+                      persistent <- readBool()
+                    } yield Send(chan, dataSeq, persistent)
+
+                  case _ =>
+                    Sync[F].raiseError(
+                      new IllegalArgumentException("Invalid tag for Par deserialization")
+                    )
+                }
+        } yield par
+      readPar()
+    }
+  }
+}

--- a/models/src/main/scala/coop/rchain/models/rholangN/implicits.scala
+++ b/models/src/main/scala/coop/rchain/models/rholangN/implicits.scala
@@ -1,0 +1,3 @@
+package coop.rchain.models.rholangN
+
+object implicits {}

--- a/models/src/test/scala/coop/rchain/models/rholangN/ParTest.scala
+++ b/models/src/test/scala/coop/rchain/models/rholangN/ParTest.scala
@@ -1,0 +1,19 @@
+package coop.rchain.models.rholangN
+
+import coop.rchain.models.rholangN
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
+import scodec.bits.ByteVector
+
+class ParSpec extends AnyFlatSpec with ScalaCheckPropertyChecks with Matchers {
+
+  behavior of "Par"
+
+  it should "test Pars" in {
+    val left            = GNil()
+    val tmp: ByteVector = left.toBytes
+    val right           = Par.fromBytes(tmp)
+    left should be(right)
+  }
+}

--- a/models/src/test/scala/coop/rchain/models/rholangN/StackSafetySpec.scala
+++ b/models/src/test/scala/coop/rchain/models/rholangN/StackSafetySpec.scala
@@ -1,0 +1,80 @@
+package coop.rchain.models.rholangN
+
+import cats.Eval
+import coop.rchain.catscontrib.effect.implicits.sEval
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import scala.annotation.tailrec
+import scala.collection.immutable.Seq
+
+class StackSafetySpec extends AnyFlatSpec with Matchers {
+
+  def findMaxRecursionDepth(): Int = {
+    def count(i: Int): Int =
+      try {
+        count(i + 1) //apparently, the try-catch is enough for tailrec to not work. Lucky!
+      } catch {
+        case _: StackOverflowError => i
+      }
+    println("About to find max recursion depth for this test run")
+    val maxDepth = count(0)
+    println(s"Calculated max recursion depth is $maxDepth")
+    // Because of OOM errors on CI depth recursion is limited
+    val maxDepthLimited = Math.min(1500, maxDepth)
+    println(s"Used recursion depth is limited to $maxDepthLimited")
+    maxDepthLimited
+  }
+
+  "Rholang par" should "not blow up on a huge structure with List" in {
+    import coop.rchain.models.Expr.ExprInstance.GInt
+    import coop.rchain.models._
+    import coop.rchain.models.serialization.implicits._
+    import coop.rchain.shared.Serialize
+    import coop.rchain.models.rholang.implicits._
+
+    @tailrec
+    def hugePar(n: Int, par: Par = Par(exprs = Seq(GInt(0)))): Par =
+      if (n == 0) par
+      else hugePar(n - 1, Par(exprs = Seq(EList(Seq(par)))))
+
+    val maxRecursionDepth: Int = findMaxRecursionDepth()
+    val par                    = hugePar(maxRecursionDepth)
+    val anotherPar             = hugePar(maxRecursionDepth)
+
+    noException shouldBe thrownBy {
+      ProtoM.serializedSize(par).value
+
+      val encoded = Serialize[Par].encode(par)
+      Serialize[Par].decode(encoded)
+
+      HashM[Par].hash[Eval](par).value
+      par.hashCode()
+
+      EqualM[Par].equal[Eval](par, anotherPar).value
+      par == anotherPar
+    }
+  }
+  "RholangN par" should "not blow up on a huge structure with List" in {
+
+    @tailrec
+    def hugePar(n: Int, par: Par = GInt(0)): Par =
+      if (n == 0) par
+      else hugePar(n - 1, EList(par))
+
+    val maxRecursionDepth: Int = findMaxRecursionDepth()
+    val par                    = hugePar(maxRecursionDepth)
+    val anotherPar             = hugePar(maxRecursionDepth)
+
+    noException shouldBe thrownBy {
+      val sData   = par.toBytes
+      val decoded = Par.fromBytes(sData)
+      assert(par == decoded)
+      assert(par.rhoHash == anotherPar.rhoHash)
+      assert(par.hashCode == anotherPar.hashCode)
+      assert(par.serializedSize == anotherPar.serializedSize)
+      assert(par == anotherPar)
+      par == anotherPar
+    }
+  }
+}

--- a/models/src/test/scala/coop/rchain/models/rholangN/StackSafetySpec.scala
+++ b/models/src/test/scala/coop/rchain/models/rholangN/StackSafetySpec.scala
@@ -21,7 +21,7 @@ class StackSafetySpec extends AnyFlatSpec with Matchers {
     val maxDepth = count(0)
     println(s"Calculated max recursion depth is $maxDepth")
     // Because of OOM errors on CI depth recursion is limited
-    val maxDepthLimited = Math.min(1500, maxDepth)
+    val maxDepthLimited = Math.min(500, maxDepth)
     println(s"Used recursion depth is limited to $maxDepthLimited")
     maxDepthLimited
   }
@@ -65,13 +65,12 @@ class StackSafetySpec extends AnyFlatSpec with Matchers {
     val maxRecursionDepth: Int = findMaxRecursionDepth()
     val par                    = hugePar(maxRecursionDepth)
     val anotherPar             = hugePar(maxRecursionDepth)
-
+    val _                      = par.locallyFree
     noException shouldBe thrownBy {
       val sData   = par.toBytes
       val decoded = Par.fromBytes(sData)
       assert(par == decoded)
       assert(par.rhoHash == anotherPar.rhoHash)
-      assert(par.hashCode == anotherPar.hashCode)
       assert(par.serializedSize == anotherPar.serializedSize)
       assert(par == anotherPar)
       par == anotherPar

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/EvalTest.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/EvalTest.scala
@@ -1,0 +1,53 @@
+package coop.rchain.rholang.interpreter
+
+import cats.effect.IO
+import cats.effect.unsafe.implicits.global
+import coop.rchain.metrics
+import coop.rchain.metrics.{Metrics, NoopSpan, Span}
+import coop.rchain.models.Expr.ExprInstance.GString
+import coop.rchain.models.Par
+import coop.rchain.models.rholang.implicits._
+import coop.rchain.rholang.Resources.mkRuntime
+import coop.rchain.rholang.interpreter.compiler.Compiler
+import coop.rchain.rholang.syntax._
+import coop.rchain.shared.Log
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+class EvalTest extends AnyWordSpec with Matchers {
+  implicit val logF: Log[IO]            = Log.log[IO]
+  implicit val noopMetrics: Metrics[IO] = new metrics.Metrics.MetricsNOP[IO]
+  implicit val noopSpan: Span[IO]       = NoopSpan[IO]()
+
+  val outcomeCh      = "ret"
+  val reduceErrorMsg = "Error: index out of bound: -1"
+
+  private def execute(source: String): IO[Par] =
+    mkRuntime[IO]("rholang-eval-spec")
+      .use { runtime =>
+        for {
+          _    <- runtime.evaluate(source)
+          data <- runtime.getData(GString(outcomeCh)).map(_.head)
+        } yield data.a.pars.head
+      }
+
+  "runtime" should {
+    "convert term to Par and evalue it" in {
+//      val term = """{ "key11"|"key12":"data1", "key2":"data2"}"""
+      val term = """ new x, y in { x!(*y) | for ( @data <- x) {data} } """
+      val ast  = Compiler[IO].sourceToADT(term).unsafeRunSync()
+      println("AST:")
+      println(ast)
+
+      val term2    = s"""@"$outcomeCh"!($term)"""
+      val evalTerm = execute(term2).unsafeRunSync()
+      println("evalTerm:")
+      println(evalTerm)
+
+      val term3         = s""" @"chan"!( $term ) | for(@q <- @"chan") { @"$outcomeCh"!(q) } """
+      val processedTerm = execute(term3).unsafeRunSync()
+      println("processedTerm:")
+      println(processedTerm)
+    }
+  }
+}

--- a/rspace-bench/src/test/scala/coop/rchain/models/rholang/ParBench.scala
+++ b/rspace-bench/src/test/scala/coop/rchain/models/rholang/ParBench.scala
@@ -1,0 +1,168 @@
+package coop.rchain.models.rholang
+
+import cats.Eval
+import coop.rchain.catscontrib.effect.implicits.sEval
+import org.openjdk.jmh.annotations._
+import scodec.bits.ByteVector
+
+import java.util.concurrent.TimeUnit
+import scala.annotation.tailrec
+import coop.rchain.models.Expr.ExprInstance._
+import coop.rchain.models._
+import coop.rchain.models.serialization.implicits._
+import coop.rchain.shared.Serialize
+import coop.rchain.models.rholang.implicits._
+
+@Fork(value = 1)
+@Warmup(iterations = 5)
+@Measurement(iterations = 5)
+@OperationsPerInvocation(value = 100)
+@State(Scope.Benchmark)
+class ParBench {
+
+  def findMaxRecursionDepth(): Int = {
+    def count(i: Int): Int =
+      try {
+        count(i + 1) //apparently, the try-catch is enough for tailrec to not work. Lucky!
+      } catch {
+        case _: StackOverflowError => i
+      }
+
+    println("About to find max recursion depth for this test run")
+    val maxDepth = count(0)
+    println(s"Calculated max recursion depth is $maxDepth")
+    // Because of OOM errors on CI depth recursion is limited
+    val maxDepthLimited = Math.min(1000, maxDepth)
+    println(s"Used recursion depth is limited to $maxDepthLimited")
+    maxDepthLimited
+  }
+
+  @tailrec
+  final def createNestedPar(n: Int, par: Par = Par(exprs = Seq(GInt(0)))): Par =
+    if (n == 0) par
+    else createNestedPar(n - 1, Par(exprs = Seq(EList(Seq(par)))))
+
+  final def createParProc(n: Int): Par = {
+    val elSize     = 33
+    def el(i: Int) = EListBody(EList(Seq.fill(elSize)(GInt(i.toLong))))
+    Par(exprs = Seq.tabulate(n)(el))
+  }
+
+  var maxRecursionDepth: Int     = _
+  var nestedPar: Par             = _
+  var nestedAnotherPar: Par      = _
+  var nestedParSData: ByteVector = _
+
+  val parProcSize: Int         = 1000
+  var parProc: Par             = _
+  var parProcAnother: Par      = _
+  var parProcSData: ByteVector = _
+  @Setup(Level.Trial)
+  def setup(): Unit = {
+    maxRecursionDepth = findMaxRecursionDepth()
+    nestedPar = createNestedPar(maxRecursionDepth)
+    nestedAnotherPar = createNestedPar(maxRecursionDepth)
+    nestedParSData = Serialize[Par].encode(nestedPar)
+
+    parProc = createParProc(parProcSize)
+    parProcSData = Serialize[Par].encode(parProc)
+  }
+
+  @Benchmark
+  @BenchmarkMode(Array(Mode.AverageTime))
+  @OutputTimeUnit(TimeUnit.NANOSECONDS)
+  def nestedCreation(): Unit = {
+    val _ = createNestedPar(maxRecursionDepth)
+  }
+
+  @Benchmark
+  @BenchmarkMode(Array(Mode.AverageTime))
+  @OutputTimeUnit(TimeUnit.NANOSECONDS)
+  def nestedSerialization(): Unit = {
+    val _ = Serialize[Par].encode(nestedPar)
+  }
+
+  @Benchmark
+  @BenchmarkMode(Array(Mode.AverageTime))
+  @OutputTimeUnit(TimeUnit.NANOSECONDS)
+  def nestedDeserialization(): Unit = {
+    val _ = Serialize[Par].decode(nestedParSData)
+  }
+
+  @Benchmark
+  @BenchmarkMode(Array(Mode.AverageTime))
+  @OutputTimeUnit(TimeUnit.NANOSECONDS)
+  def nestedSerializedSize(): Unit = {
+    val _ = ProtoM.serializedSize(nestedPar).value
+  }
+
+  @Benchmark
+  @BenchmarkMode(Array(Mode.AverageTime))
+  @OutputTimeUnit(TimeUnit.NANOSECONDS)
+  def nestedHash(): Unit = {
+    val _ = HashM[Par].hash[Eval](nestedPar).value
+  }
+
+  @Benchmark
+  @BenchmarkMode(Array(Mode.AverageTime))
+  @OutputTimeUnit(TimeUnit.NANOSECONDS)
+  def nestedEqual(): Unit = {
+    val _ = EqualM[Par].equal[Eval](nestedPar, nestedAnotherPar).value
+  }
+
+  @Benchmark
+  @BenchmarkMode(Array(Mode.AverageTime))
+  @OutputTimeUnit(TimeUnit.NANOSECONDS)
+  def nestedAdd(): Unit = {
+    val _ = nestedPar.addExprs(GInt(0))
+  }
+
+  @Benchmark
+  @BenchmarkMode(Array(Mode.AverageTime))
+  @OutputTimeUnit(TimeUnit.NANOSECONDS)
+  def parProcCreation(): Unit = {
+    val _ = createParProc(parProcSize)
+  }
+
+  @Benchmark
+  @BenchmarkMode(Array(Mode.AverageTime))
+  @OutputTimeUnit(TimeUnit.NANOSECONDS)
+  def parProcSerialization(): Unit = {
+    val _ = Serialize[Par].encode(parProc)
+  }
+
+  @Benchmark
+  @BenchmarkMode(Array(Mode.AverageTime))
+  @OutputTimeUnit(TimeUnit.NANOSECONDS)
+  def parProcDeserialization(): Unit = {
+    val _ = Serialize[Par].decode(parProcSData)
+  }
+
+  @Benchmark
+  @BenchmarkMode(Array(Mode.AverageTime))
+  @OutputTimeUnit(TimeUnit.NANOSECONDS)
+  def parProcSerializedSize(): Unit = {
+    val _ = ProtoM.serializedSize(parProc).value
+  }
+
+  @Benchmark
+  @BenchmarkMode(Array(Mode.AverageTime))
+  @OutputTimeUnit(TimeUnit.NANOSECONDS)
+  def parProcHash(): Unit = {
+    val _ = HashM[Par].hash[Eval](parProc).value
+  }
+
+  @Benchmark
+  @BenchmarkMode(Array(Mode.AverageTime))
+  @OutputTimeUnit(TimeUnit.NANOSECONDS)
+  def parProcEqual(): Unit = {
+    val _ = EqualM[Par].equal[Eval](parProc, parProcAnother).value
+  }
+
+  @Benchmark
+  @BenchmarkMode(Array(Mode.AverageTime))
+  @OutputTimeUnit(TimeUnit.NANOSECONDS)
+  def parProcAdd(): Unit = {
+    val _ = parProc.addExprs(GInt(0))
+  }
+}

--- a/rspace-bench/src/test/scala/coop/rchain/models/rholangN/ParBench.scala
+++ b/rspace-bench/src/test/scala/coop/rchain/models/rholangN/ParBench.scala
@@ -13,23 +13,6 @@ import scala.annotation.tailrec
 @State(Scope.Benchmark)
 class ParBench {
 
-  def findMaxRecursionDepth(): Int = {
-    def count(i: Int): Int =
-      try {
-        count(i + 1) //apparently, the try-catch is enough for tailrec to not work. Lucky!
-      } catch {
-        case _: StackOverflowError => i
-      }
-
-    println("About to find max recursion depth for this test run")
-    val maxDepth = count(0)
-    println(s"Calculated max recursion depth is $maxDepth")
-    // Because of OOM errors on CI depth recursion is limited
-    val maxDepthLimited = Math.min(1000, maxDepth)
-    println(s"Used recursion depth is limited to $maxDepthLimited")
-    maxDepthLimited
-  }
-
   @tailrec
   final def createNestedPar(n: Int, par: Par = GInt(0)): Par =
     if (n == 0) par
@@ -42,20 +25,29 @@ class ParBench {
     ParProc(seq)
   }
 
-  var maxRecursionDepth: Int     = _
+  final def appendTest(n: Int): Par = {
+    val elSize     = 33
+    def el(i: Int) = EList(Seq.fill(elSize)(GInt(i.toLong)))
+
+    val seq = Seq.tabulate(n)(el)
+    seq.foldLeft(ParProc(Seq())) { (acc, p) =>
+      acc.add(p)
+    }
+  }
+  val nestedSize: Int            = 500
   var nestedPar: Par             = _
   var nestedAnotherPar: Par      = _
   var nestedParSData: ByteVector = _
 
-  val parProcSize: Int         = 1000
+  val parProcSize: Int         = 500
   var parProc: Par             = _
   var parProcAnother: Par      = _
   var parProcSData: ByteVector = _
-  @Setup(Level.Trial)
+
+  @Setup(Level.Iteration)
   def setup(): Unit = {
-    maxRecursionDepth = findMaxRecursionDepth()
-    nestedPar = createNestedPar(maxRecursionDepth)
-    nestedAnotherPar = createNestedPar(maxRecursionDepth)
+    nestedPar = createNestedPar(nestedSize)
+    nestedAnotherPar = createNestedPar(nestedSize)
     nestedParSData = nestedPar.toBytes
 
     parProc = createParProc(parProcSize)
@@ -67,7 +59,7 @@ class ParBench {
   @BenchmarkMode(Array(Mode.AverageTime))
   @OutputTimeUnit(TimeUnit.NANOSECONDS)
   def nestedCreation(): Unit = {
-    val _ = createNestedPar(maxRecursionDepth)
+    val _ = createNestedPar(nestedSize)
   }
 
   @Benchmark
@@ -160,5 +152,12 @@ class ParBench {
       case proc: ParProc => proc.add(GInt(0))
       case _             => assert(false)
     }
+  }
+
+  @Benchmark
+  @BenchmarkMode(Array(Mode.AverageTime))
+  @OutputTimeUnit(TimeUnit.NANOSECONDS)
+  def manyAppends(): Unit = {
+    val _ = appendTest(parProcSize)
   }
 }

--- a/rspace-bench/src/test/scala/coop/rchain/models/rholangN/ParBench.scala
+++ b/rspace-bench/src/test/scala/coop/rchain/models/rholangN/ParBench.scala
@@ -1,0 +1,164 @@
+package coop.rchain.models.rholangN
+
+import org.openjdk.jmh.annotations._
+import scodec.bits.ByteVector
+
+import java.util.concurrent.TimeUnit
+import scala.annotation.tailrec
+
+@Fork(value = 1)
+@Warmup(iterations = 5)
+@Measurement(iterations = 5)
+@OperationsPerInvocation(value = 100)
+@State(Scope.Benchmark)
+class ParBench {
+
+  def findMaxRecursionDepth(): Int = {
+    def count(i: Int): Int =
+      try {
+        count(i + 1) //apparently, the try-catch is enough for tailrec to not work. Lucky!
+      } catch {
+        case _: StackOverflowError => i
+      }
+
+    println("About to find max recursion depth for this test run")
+    val maxDepth = count(0)
+    println(s"Calculated max recursion depth is $maxDepth")
+    // Because of OOM errors on CI depth recursion is limited
+    val maxDepthLimited = Math.min(1000, maxDepth)
+    println(s"Used recursion depth is limited to $maxDepthLimited")
+    maxDepthLimited
+  }
+
+  @tailrec
+  final def createNestedPar(n: Int, par: Par = GInt(0)): Par =
+    if (n == 0) par
+    else createNestedPar(n - 1, EList(par))
+
+  final def createParProc(n: Int): Par = {
+    val elSize     = 33
+    def el(i: Int) = EList(Seq.fill(elSize)(GInt(i.toLong)))
+    val seq        = Seq.tabulate(n)(el)
+    ParProc(seq)
+  }
+
+  var maxRecursionDepth: Int     = _
+  var nestedPar: Par             = _
+  var nestedAnotherPar: Par      = _
+  var nestedParSData: ByteVector = _
+
+  val parProcSize: Int         = 1000
+  var parProc: Par             = _
+  var parProcAnother: Par      = _
+  var parProcSData: ByteVector = _
+  @Setup(Level.Trial)
+  def setup(): Unit = {
+    maxRecursionDepth = findMaxRecursionDepth()
+    nestedPar = createNestedPar(maxRecursionDepth)
+    nestedAnotherPar = createNestedPar(maxRecursionDepth)
+    nestedParSData = nestedPar.toBytes
+
+    parProc = createParProc(parProcSize)
+    parProcAnother = createParProc(parProcSize)
+    parProcSData = parProc.toBytes
+  }
+
+  @Benchmark
+  @BenchmarkMode(Array(Mode.AverageTime))
+  @OutputTimeUnit(TimeUnit.NANOSECONDS)
+  def nestedCreation(): Unit = {
+    val _ = createNestedPar(maxRecursionDepth)
+  }
+
+  @Benchmark
+  @BenchmarkMode(Array(Mode.AverageTime))
+  @OutputTimeUnit(TimeUnit.NANOSECONDS)
+  def nestedSerialization(): Unit = {
+    val _ = nestedPar.toBytes
+  }
+
+  @Benchmark
+  @BenchmarkMode(Array(Mode.AverageTime))
+  @OutputTimeUnit(TimeUnit.NANOSECONDS)
+  def nestedDeserialization(): Unit = {
+    val _ = Par.fromBytes(nestedParSData)
+  }
+
+  @Benchmark
+  @BenchmarkMode(Array(Mode.AverageTime))
+  @OutputTimeUnit(TimeUnit.NANOSECONDS)
+  def nestedSerializedSize(): Unit = {
+    val _ = nestedPar.serializedSize
+  }
+
+  @Benchmark
+  @BenchmarkMode(Array(Mode.AverageTime))
+  @OutputTimeUnit(TimeUnit.NANOSECONDS)
+  def nestedHash(): Unit = {
+    val _ = nestedPar.rhoHash
+  }
+
+  @Benchmark
+  @BenchmarkMode(Array(Mode.AverageTime))
+  @OutputTimeUnit(TimeUnit.NANOSECONDS)
+  def nestedEqual(): Unit = {
+    val _ = nestedPar.equals(nestedAnotherPar)
+  }
+
+  @Benchmark
+  @BenchmarkMode(Array(Mode.AverageTime))
+  @OutputTimeUnit(TimeUnit.NANOSECONDS)
+  def nestedAdd(): Unit =
+    ParProc(Seq(nestedPar, GInt(0)))
+
+  @Benchmark
+  @BenchmarkMode(Array(Mode.AverageTime))
+  @OutputTimeUnit(TimeUnit.NANOSECONDS)
+  def parProcCreation(): Unit = {
+    val _ = createParProc(parProcSize)
+  }
+
+  @Benchmark
+  @BenchmarkMode(Array(Mode.AverageTime))
+  @OutputTimeUnit(TimeUnit.NANOSECONDS)
+  def parProcSerialization(): Unit = {
+    val _ = parProc.toBytes
+  }
+
+  @Benchmark
+  @BenchmarkMode(Array(Mode.AverageTime))
+  @OutputTimeUnit(TimeUnit.NANOSECONDS)
+  def parProcDeserialization(): Unit = {
+    val _ = Par.fromBytes(parProcSData)
+  }
+  @Benchmark
+  @BenchmarkMode(Array(Mode.AverageTime))
+  @OutputTimeUnit(TimeUnit.NANOSECONDS)
+  def parProcSerializedSize(): Unit = {
+    val _ = parProc.serializedSize
+  }
+
+  @Benchmark
+  @BenchmarkMode(Array(Mode.AverageTime))
+  @OutputTimeUnit(TimeUnit.NANOSECONDS)
+  def parProcHash(): Unit = {
+    val _ = parProc.rhoHash
+  }
+
+  @Benchmark
+  @BenchmarkMode(Array(Mode.AverageTime))
+  @OutputTimeUnit(TimeUnit.NANOSECONDS)
+  def parProcEqual(): Unit = {
+    val _ = parProc.equals(parProcAnother)
+  }
+
+  @Benchmark
+  @BenchmarkMode(Array(Mode.AverageTime))
+  @OutputTimeUnit(TimeUnit.NANOSECONDS)
+  def parProcAdd(): Unit = {
+    val _ = parProc match {
+      case proc: ParProc => proc.add(GInt(0))
+      case _             => assert(false)
+    }
+  }
+}


### PR DESCRIPTION
## Overview
This code is intended to create an example for a small number of Rolang types. After debugging, it will be possible to apply this approach to other types. Features: excessive nesting removed, hashing mechanism modified, sorting mechanism modified.
The main advantage is that the new sorting algorithm provides faster modification of existing pairs. Because it does not require rehashing all the elements in them.

### Added rho types Par, List, Int, Nil, Send:
[/models/src/main/scala/coop/rchain/models/rholangN/Par.scala#L10](https://github.com/rchain/rchain/blob/19a0b7bf90d5aa41fef2071a02b2499476d09fd0/models/src/main/scala/coop/rchain/models/rholangN/Par.scala#L10)

### Added hashing and serialization/deserialization mechanism
[/models/src/main/scala/coop/rchain/models/rholangN/ParManager.scala#L112](https://github.com/rchain/rchain/blob/19a0b7bf90d5aa41fef2071a02b2499476d09fd0/models/src/main/scala/coop/rchain/models/rholangN/ParManager.scala#L112)
[/models/src/main/scala/coop/rchain/models/rholangN/ParManager.scala#L208](https://github.com/rchain/rchain/blob/19a0b7bf90d5aa41fef2071a02b2499476d09fd0/models/src/main/scala/coop/rchain/models/rholangN/ParManager.scala#L208)

### Comparing results with old Pars
Benchmark for old pars  (rholang):
[/rspace-bench/src/test/scala/coop/rchain/models/rholang/ParBench.scala#L21](https://github.com/rchain/rchain/blob/19a0b7bf90d5aa41fef2071a02b2499476d09fd0/rspace-bench/src/test/scala/coop/rchain/models/rholang/ParBench.scala#L21)
n=1000
```scala
  final def createNestedPar(n: Int, par: Par = Par(exprs = Seq(GInt(0)))): Par =
    if (n == 0) par
    else createNestedPar(n - 1, Par(exprs = Seq(EList(Seq(par)))))

  final def createParProc(n: Int): Par = {
    val elSize     = 33
    def el(i: Int) = EListBody(EList(Seq.fill(elSize)(GInt(i.toLong))))
    Par(exprs = Seq.tabulate(n)(el))
  }
```

Benchmark for new pars (rholangN):
[/rspace-bench/src/test/scala/coop/rchain/models/rholangN/ParBench.scala#L14](https://github.com/rchain/rchain/blob/19a0b7bf90d5aa41fef2071a02b2499476d09fd0/rspace-bench/src/test/scala/coop/rchain/models/rholangN/ParBench.scala#L14)
n=1000
```scala
  final def createNestedPar(n: Int, par: Par = GInt(0)): Par =
    if (n == 0) par
    else createNestedPar(n - 1, EList(par))

  final def createParProc(n: Int): Par = {
    val elSize     = 33
    def el(i: Int) = EList(Seq.fill(elSize)(GInt(i.toLong)))
    val seq        = Seq.tabulate(n)(el)
    ParProc(seq)
  }
```

Results:
| Function in benckmark                          | Description             | Impl | Time        | Unit                           |
|------------------------------------------------|-------------------------|------|-------------|--------------------------------|
| c.r.m.rholang.ParBench.nestedCreation          | Create                  | Old  | 692.718     | ns/op                          |
| c.r.m.rholangN.ParBench.nestedCreation         | Create                  | New  | 8551.983    | ns/op                          |
|                                                |                         |      |             |                                |
| c.r.m.rholang.ParBench.nestedDeserialization   | Deserialization         | Old  | 74773.885   | ns/op                          |
| c.r.m.rholangN.ParBench.nestedDeserialization  | Deserialization         | New  | 18991.985   | ns/op                          |
|                                                |                         |      |             |                                |
| c.r.m.rholang.ParBench.nestedEqual             | Equal                   | Old  | 126077.304  | ns/op                          |
| c.r.m.rholangN.ParBench.nestedEqual            | Equal                   | New  | 3.907       | ns/op                          |
|                                                |                         |      |             |                                |
| c.r.m.rholang.ParBench.nestedHash              | Hash calc               | Old  | 105688.461  | ns/op                          |
| c.r.m.rholangN.ParBench.nestedHash             | Hash calc               | New  | 0.009       | ns/op                          |
|                                                |                         |      |             |                                |
| c.r.m.rholang.ParBench.nestedSerialization     | Serialization           | Old  | 235523.793  | ns/op                          |
| c.r.m.rholangN.ParBench.nestedSerialization    | Serialization           | New  | 4307.767    | ns/op                          |
|                                                |                         |      |             |                                |
| c.r.m.rholang.ParBench.nestedSerializedSize    | Calc serialization time | Old  | 39.551      | ns/op                          |
| c.r.m.rholangN.ParBench.nestedSerializedSize   | Calc serialization time | New  | 0.009       | ns/op                          |
|                                                |                         |      |             |                                |
| c.r.m.rholang.ParBench.nestedAdd               | Append one element      | Old  | 0.737       | ns/op                          |
| c.r.m.rholangN.ParBench.nestedAdd              | Append one element      | New  | 12.387      | ns/op                          |
|                                                |                         |      |             |                                |
| c.r.m.rholang.ParBench.parProcCreation         | Create                  | Old  | 47979.706   | ns/op                          |
| c.r.m.rholangN.ParBench.parProcCreation        | Create                  | New  | 142205.877  | ns/op                          |
|                                                |                         |      |             |                                |
| c.r.m.rholang.ParBench.parProcDeserialization  | Deserialization         | Old  | 1622127.727 | ns/op                          |
| c.r.m.rholangN.ParBench.parProcDeserialization | Deserialization         | New  | 330164.607  | ns/op                          |
|                                                |                         |      |             |                                |
| c.r.m.rholang.ParBench.parProcHash             | Equal                   | Old  | 2512833.536 | ns/op                          |
| c.r.m.rholangN.ParBench.parProcHash            | Equal                   | New  | 0.009       | ns/op                          |
|                                                |                         |      |             |                                |
| c.r.m.rholang.ParBench.parProcEqual            | Hash calc               | Old  | ERROR       | java.lang.NullPointerException |
| c.r.m.rholangN.ParBench.parProcEqual           | Hash calc               | New  | 3.905       | ns/op                          |
|                                                |                         |      |             |                                |
| c.r.m.rholang.ParBench.parProcSerialization    | Serialization           | Old  | 5532719.832 | ns/op                          |
| c.r.m.rholangN.ParBench.parProcSerialization   | Serialization           | New  | 166067.536  | ns/op                          |
|                                                |                         |      |             |                                |
| c.r.m.rholang.ParBench.parProcSerializedSize   | Calc serialization time | Old  | 5134.994    | ns/op                          |
| c.r.m.rholangN.ParBench.parProcSerializedSize  | Calc serialization time | New  | 0.009       | ns/op                          |
|                                                |                         |      |             |                                |
| c.r.m.rholang.ParBench.parProcAdd              | Append one element      | Old  | 72.138      | ns/op                          |
| c.r.m.rholangN.ParBench.parProcAdd             | Append one element      | New  | 2834.029    | ns/op                          |

The main advantage here: 
|                                    |                    |     |          |       |
|------------------------------------|--------------------|-----|----------|-------|
| c.r.m.rholang.ParBench.nestedAdd   | Append one element | Old | 0.737    | ns/op |
| c.r.m.rholangN.ParBench.nestedAdd  | Append one element | New | 12.387   | ns/op |
|                                    |                    |     |          |       |
| c.r.m.rholang.ParBench.parProcAdd  | Append one element | Old | 72.138   | ns/op |
| c.r.m.rholangN.ParBench.parProcAdd | Append one element | New | 2834.029 | ns/op |

You can say: what is the advantage if it became slower than it was? But keep in mind that in the new implementation, the hash is immediately calculated and sorted. To calculate the hash in the old implementation after the addition operation, it will take many times more time (see rholang.ParBench.parProcHash and rholang.ParBench.nestedHash).

### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
